### PR TITLE
Add Go specific EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,12 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
+max_line_length = 79
+
+[*.go]
+indent_style = tabs
+indent_size = 4
+max_line_length = ignore
 
 [*.html]
 indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf
 *.png binary


### PR DESCRIPTION
https://go.dev/doc/effective_go#formatting defines that we should use tabs for
indents and there is no line length limit.
