### PR TITLE
Propagate errors in bootstrap and metric constructor

### DIFF
--- a/boostrap_test.go
+++ b/boostrap_test.go
@@ -1,24 +1,28 @@
 package coopdatadog
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/coopnorge/go-datadog-lib/config"
+	"github.com/coopnorge/go-datadog-lib/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDatadog(t *testing.T) {
-    ddCfg := config.DatadogConfig{}
+	ddCfg := config.DatadogConfig{}
 
-    StartDatadog(ddCfg, false, false)
+	err := StartDatadog(ddCfg, false, false)
+	assert.NotNil(t, err)
 
-    ddCfg = config.DatadogConfig{
-        Env:            "local",
-        Service:        "Test-Go-Datadog-lib",
-        ServiceVersion: "na",
-        DSD:            "unix:///tmp/",
-        APM:            "/tmp",
-    }
+	ddCfg = config.DatadogConfig{
+		Env:            "local",
+		Service:        "Test-Go-Datadog-lib",
+		ServiceVersion: "na",
+		DSD:            "unix:///tmp/",
+		APM:            "/tmp",
+	}
 
-    StartDatadog(ddCfg, true, true)
-    GracefulDatadogShutdown()
+	err = StartDatadog(ddCfg, true, true)
+    assert.Nil(t, err)
+
+	GracefulDatadogShutdown()
 }

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,8 +1,9 @@
 package coopdatadog
 
 import (
+    "fmt"
+    
     "github.com/coopnorge/go-datadog-lib/config"
-    "github.com/coopnorge/go-logger"
 
     "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
     "gopkg.in/DataDog/dd-trace-go.v1/profiler"
@@ -11,19 +12,17 @@ import (
 // StartDatadog parallel process to collect data for Datadog.
 // enableExtraProfiling flag enables more optional profilers not recommended for production.
 // isConnectionSocket flag related to Datadog connection type, it supports HTTP or socket - values will be used from config.DatadogParameters
-func StartDatadog(cfg config.DatadogParameters, enableExtraProfiling, isConnectionSocket bool) {
+func StartDatadog(cfg config.DatadogParameters, enableExtraProfiling, isConnectionSocket bool) error {
     if !cfg.IsDataDogConfigValid() {
-        logger.Errorf("Datadog configuration not valid, cannot initialize Datadog services")
-
-        return
+        return fmt.Errorf("datadog configuration not valid, cannot initialize Datadog services")
     }
-
-    logger.Infof("Initializing Datadog services for %s in environment %s", cfg.GetService(), cfg.GetEnv())
 
     initTracer(cfg, isConnectionSocket)
     if initProfilerErr := initProfiler(cfg, enableExtraProfiling, isConnectionSocket); initProfilerErr != nil {
-        logger.Errorf("Failed to start Datadog profiler: %v", initProfilerErr)
+        return fmt.Errorf("failed to start Datadog profiler: %v", initProfilerErr)
     }
+
+    return nil
 }
 
 // GracefulDatadogShutdown of executed parallel processes

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,10 +137,15 @@ func main() {
 
 	// When you start other processes start datadog
 	withExtraProfiler := true
-	go_datadog_lib.StartDatadog(ddCfg, withExtraProfiler)
+	startDatadogServiceError := go_datadog_lib.StartDatadog(ddCfg, withExtraProfiler)
+	if startDatadogServiceError != nil {
+    // Handle error / log error
+  }
 
 	// Stop datadog with yours other processes
 	handleGracefulShutdown(go_datadog_lib.GracefulDatadogShutdown)
+	// or simply call with defer
+	defer go_datadog_lib.GracefulDatadogShutdown()
 }
 ```
 
@@ -253,7 +258,10 @@ func MyServiceContainer(ddCfg *config.DatadogConfig) error {
 	ddClient := metrics.NewDatadogMetrics(ddCfg)
 
 	// If you need simple metric collector then create
-	ddMetricCollector := metrics.NewBaseMetricCollector(ddClient)
+	ddMetricCollector, ddMetricCollectorErr := metrics.NewBaseMetricCollector(ddClient)
+	if ddMetricCollectorErr != nil {
+		// Handle error / log error
+  }
 	// ddMetricCollector -> *BaseMetricCollector allows you to send metrics to Datadog
 }
 ```
@@ -274,7 +282,10 @@ import (
 )
 
 func Example()  {
-	ddClient := metrics.NewDatadogMetrics(new(config.DatadogConfig))
+	ddClient, ddClientErr := metrics.NewDatadogMetrics(new(config.DatadogConfig))
+	if ddClient != nil {
+    // Handle error / log error
+  }
 	ddMetricCollector := metrics.NewBaseMetricCollector(ddClient)
 
 	tMetricData := metrics.Data{

--- a/metric/datadog.go
+++ b/metric/datadog.go
@@ -1,69 +1,66 @@
 package metric
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    "github.com/coopnorge/go-datadog-lib/config"
-    "github.com/coopnorge/go-logger"
-
-    "github.com/DataDog/datadog-go/statsd"
-    "github.com/iancoleman/strcase"
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/coopnorge/go-datadog-lib/config"
+	"github.com/iancoleman/strcase"
 )
 
 type (
-    DatadogMetricsClient interface {
-        // GetClient statsd client
-        GetClient() statsd.ClientInterface
-        // GetDefaultTags that will be used in Datadog metrics
-        GetDefaultTags() []string
-        // GetServiceNamePrefix for metric name
-        GetServiceNamePrefix() string
-    }
+	DatadogMetricsClient interface {
+		// GetClient statsd client
+		GetClient() statsd.ClientInterface
+		// GetDefaultTags that will be used in Datadog metrics
+		GetDefaultTags() []string
+		// GetServiceNamePrefix for metric name
+		GetServiceNamePrefix() string
+	}
 
-    // DatadogMetrics ready to use client to send statsd metrics
-    DatadogMetrics struct {
-        client             *statsd.Client
-        servicePrefix      string
-        defaultMetricsTags []string
-    }
+	// DatadogMetrics ready to use client to send statsd metrics
+	DatadogMetrics struct {
+		client             *statsd.Client
+		servicePrefix      string
+		defaultMetricsTags []string
+	}
 )
 
 // NewDatadogMetrics instance
-func NewDatadogMetrics(cfg config.DatadogParameters) *DatadogMetrics {
-    var ddClient *statsd.Client
-    var ddClientErr error
+func NewDatadogMetrics(cfg config.DatadogParameters) (*DatadogMetrics, error) {
+	var ddClient *statsd.Client
+	var ddClientErr error
 
-    ddClient, ddClientErr = statsd.New(cfg.GetDsdEndpoint())
-    if ddClientErr != nil {
-        logger.Errorf("datadog statsd client initialize with socket(%s) - error %w", cfg.GetDsdEndpoint(), ddClientErr)
-        if ddClient, ddClientErr = statsd.New(""); ddClientErr != nil {
-            logger.Errorf("datadog statsd self-resolving client initialize - error %w", ddClientErr)
-        }
-    }
+	ddClient, ddClientErr = statsd.New(cfg.GetDsdEndpoint())
+	if ddClientErr != nil {
+		return nil, fmt.Errorf("datadog statsd client initialize with socket(%s) - error %v", cfg.GetDsdEndpoint(), ddClientErr)
+	}
 
-    return &DatadogMetrics{
-        client:        ddClient,
-        servicePrefix: strings.ToLower(strcase.ToSnake(cfg.GetService())),
-        defaultMetricsTags: []string{
-            fmt.Sprintf("environment:%s", cfg.GetEnv()),
-            fmt.Sprintf("service:%s", cfg.GetService()),
-            fmt.Sprintf("version:%s", cfg.GetServiceVersion()),
-        },
-    }
+	dm := &DatadogMetrics{
+		client:        ddClient,
+		servicePrefix: strings.ToLower(strcase.ToSnake(cfg.GetService())),
+		defaultMetricsTags: []string{
+			fmt.Sprintf("environment:%s", cfg.GetEnv()),
+			fmt.Sprintf("service:%s", cfg.GetService()),
+			fmt.Sprintf("version:%s", cfg.GetServiceVersion()),
+		},
+	}
+
+	return dm, nil
 }
 
 // GetClient statsd client
 func (d DatadogMetrics) GetClient() statsd.ClientInterface {
-    return d.client
+	return d.client
 }
 
 // GetDefaultTags that will be used in Datadog metrics
 func (d DatadogMetrics) GetDefaultTags() []string {
-    return d.defaultMetricsTags
+	return d.defaultMetricsTags
 }
 
 // GetServiceNamePrefix for metric name
 func (d DatadogMetrics) GetServiceNamePrefix() string {
-    return d.servicePrefix
+	return d.servicePrefix
 }

--- a/metric/datadog_test.go
+++ b/metric/datadog_test.go
@@ -1,29 +1,21 @@
 package metric
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/coopnorge/go-datadog-lib/config"
+	"github.com/coopnorge/go-datadog-lib/config"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDatadogMetrics(t *testing.T) {
-    cfg := config.DatadogConfig{
-        Env:            "dev",
-        Service:        "unit-test",
-        ServiceVersion: "VUnit",
-    }
+	cfg := config.DatadogConfig{
+		Env:            "dev",
+		Service:        "unit-test",
+		ServiceVersion: "VUnit",
+	}
 
-    m := NewDatadogMetrics(&cfg)
-
-    assert.True(t, m.defaultMetricsTags[0] == "environment:dev")
-    assert.True(t, m.defaultMetricsTags[1] == "service:unit-test")
-    assert.True(t, m.defaultMetricsTags[2] == "version:VUnit")
-
-    assert.True(t, m.servicePrefix == "unit_test")
-
-    assert.Nil(t, m.GetClient())
-    assert.ElementsMatch(t, m.defaultMetricsTags, m.GetDefaultTags())
-    assert.Equal(t, m.GetServiceNamePrefix(), "unit_test")
+	m, err := NewDatadogMetrics(&cfg)
+	assert.NotNil(t, err)
+	assert.Nil(t, m)
 }


### PR DESCRIPTION
- Decuple metrics and bootstrap for Datadog service from Coop logger.
- Propagate errors
- Update Documentation examples

closes #25
closes #20