### PR TITLE
Make the bootstrap API easier to use

### DIFF
--- a/boostrap_test.go
+++ b/boostrap_test.go
@@ -10,18 +10,19 @@ import (
 func TestDatadog(t *testing.T) {
 	ddCfg := config.DatadogConfig{}
 
-	err := StartDatadog(ddCfg, false, false)
+	err := StartDatadog(ddCfg, ConnectionTypeHTTP)
 	assert.NotNil(t, err)
 
 	ddCfg = config.DatadogConfig{
-		Env:            "local",
-		Service:        "Test-Go-Datadog-lib",
-		ServiceVersion: "na",
-		DSD:            "unix:///tmp/",
-		APM:            "/tmp",
+		Env:                  "local",
+		Service:              "Test-Go-Datadog-lib",
+		ServiceVersion:       "na",
+		DSD:                  "unix:///tmp/",
+		APM:                  "/tmp",
+		EnableExtraProfiling: true,
 	}
 
-	err = StartDatadog(ddCfg, true, true)
+	err = StartDatadog(ddCfg, ConnectionTypeSocket)
 	assert.Nil(t, err)
 
 	GracefulDatadogShutdown()

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,8 @@ type (
 		GetDsdEndpoint() string
 		// GetApmEndpoint Socket path or URL for APM and profiler
 		GetApmEndpoint() string
+		// IsExtraProfilingEnabled flag enables more optional profilers not recommended for production.
+		IsExtraProfilingEnabled() bool
 		// IsDataDogConfigValid method to verify if configuration values are correct
 		IsDataDogConfigValid() bool
 	}
@@ -28,6 +30,8 @@ type (
 		DSD string `mapstructure:"dd_dogstatsd_url"`
 		// APM Socket path for apm and profiler, unix prefix not needed, example: /var/run/dd/apm.socket
 		APM string `mapstructure:"dd_trace_agent_url"`
+		// EnableExtraProfiling flag enables more optional profilers not recommended for production.
+		EnableExtraProfiling bool `mapstructure:"dd_enable_extra_profiling"`
 	}
 )
 
@@ -76,4 +80,9 @@ func (d DatadogConfig) GetDsdEndpoint() string {
 // unix prefix not needed, example: /var/run/dd/apm.socket
 func (d DatadogConfig) GetApmEndpoint() string {
 	return d.APM
+}
+
+// IsExtraProfilingEnabled return true if profilers not recommended for production are enabled.
+func (d DatadogConfig) IsExtraProfilingEnabled() bool {
+	return d.EnableExtraProfiling
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,35 +114,33 @@ Create pkg configuration for bootstrap Datadog.
 package main
 
 import (
-	"github.com/coopnorge/go-datadog-lib"
+	coopdatadog "github.com/coopnorge/go-datadog-lib"
 	"github.com/coopnorge/go-datadog-lib/config"
 )
 
 func main() {
 	// Your app initialization
 	/// ... 
-
-// From your core configuration add datadog related values
+	// From your core configuration add datadog related values
 	ddCfg := config.DatadogConfig{
 		Env:            "dd_env",
 		Service:        "dd_service",
 		ServiceVersion: "dd_version",
 		DSD:            "dd_dogstatsd_url",
 		APM:            "dd_trace_agent_url",
+		EnableExtraProfiling: "dd_enable_extra_profiling"
 	}
 
 	// When you start other processes start datadog
-	isSocket := true // Will try connect via socket or if false send via HTTP
-	withExtraProfiler := true // Enables additional profiling
-	startDatadogServiceError := go_datadog_lib.StartDatadog(ddCfg, withExtraProfiler, isSocket)
+	startDatadogServiceError := coopdatadog.StartDatadog(ddCfg, coopdatadog.ConnectionTypeSocket)
 	if startDatadogServiceError != nil {
-    // Handle error / log error
-  }
+	// Handle error / log error
+	}
 
 	// Stop datadog with yours other processes
-	handleGracefulShutdown(go_datadog_lib.GracefulDatadogShutdown)
+	handleGracefulShutdown(coopdatadog.GracefulDatadogShutdown)
 	// or simply call with defer
-	defer go_datadog_lib.GracefulDatadogShutdown()
+	defer coopdatadog.GracefulDatadogShutdown()
 }
 ```
 


### PR DESCRIPTION
An enum encodes the meaning of its values. This removes the need to store the
value of the connection type flag in a variable to make it clear.

Configure extra profiling in `DatadogConfig` so that services to not have to
implement configuration support for this.

This is a breaking change.
