### PR TITLE
Update DatadogConfig parsing

### DIFF
--- a/boostrap_test.go
+++ b/boostrap_test.go
@@ -19,7 +19,7 @@ func TestDatadog(t *testing.T) {
 		ServiceVersion:       "na",
 		DSD:                  "unix:///tmp/",
 		APM:                  "/tmp",
-		EnableExtraProfiling: true,
+		EnableExtraProfiling: "true",
 	}
 
 	err = StartDatadog(ddCfg, ConnectionTypeSocket)

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"strconv"
+	"strings"
+)
+
 type (
 	// DatadogParameters for connection and configuring background process to send information to Datadog Agent
 	DatadogParameters interface {
@@ -25,13 +30,13 @@ type (
 		// Service how must be service called and displayed in Datadog system
 		Service string `mapstructure:"dd_service" json:"dd_service,omitempty"`
 		// ServiceVersion depends on system, can be Git Tag or API version
-		ServiceVersion string `mapstructure:"dd_version" json:"dd_service_version,omitempty"`
+		ServiceVersion string `mapstructure:"dd_version" json:"dd_version,omitempty"`
 		// DSD Socket path for DD StatsD, important to have unix prefix for that value, example: unix:///var/run/dd/dsd.socket
-		DSD string `mapstructure:"dd_dogstatsd_url" json:"dd_dsd,omitempty"`
-		// APM Socket path for apm and profiler, unix prefix not needed, example: /var/run/dd/apm.socket
-		APM string `mapstructure:"dd_trace_agent_url" json:"dd_apm,omitempty"`
-		// EnableExtraProfiling flag enables more optional profilers not recommended for production.
-		EnableExtraProfiling bool `mapstructure:"dd_enable_extra_profiling" json:"dd_enable_extra_profiling,omitempty"`
+		DSD string `mapstructure:"dd_dogstatsd_url" json:"dd_dogstatsd_url,omitempty"`
+		// APM Socket path for APM and profiler, unix prefix not needed, example: /var/run/dd/apm.socket
+		APM string `mapstructure:"dd_trace_agent_url" json:"dd_trace_agent_url,omitempty"`
+		// EnableExtraProfiling bool flag enables more optional profilers not recommended for production
+		EnableExtraProfiling string `mapstructure:"dd_enable_extra_profiling" json:"dd_enable_extra_profiling,omitempty"`
 	}
 )
 
@@ -84,5 +89,10 @@ func (d DatadogConfig) GetApmEndpoint() string {
 
 // IsExtraProfilingEnabled return true if profilers not recommended for production are enabled.
 func (d DatadogConfig) IsExtraProfilingEnabled() bool {
-	return d.EnableExtraProfiling
+	isEnabled, failedToConvert := strconv.ParseBool(strings.ToLower(strings.TrimSpace(d.EnableExtraProfiling)))
+	if failedToConvert != nil {
+		return false
+	}
+
+	return isEnabled
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,7 +89,7 @@ func (d DatadogConfig) GetApmEndpoint() string {
 
 // IsExtraProfilingEnabled return true if profilers not recommended for production are enabled.
 func (d DatadogConfig) IsExtraProfilingEnabled() bool {
-	isEnabled, failedToConvert := strconv.ParseBool(strings.ToLower(strings.TrimSpace(d.EnableExtraProfiling)))
+	isEnabled, failedToConvert := strconv.ParseBool(strings.TrimSpace(d.EnableExtraProfiling))
 	if failedToConvert != nil {
 		return false
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,4 +52,41 @@ func TestConfigGetters(t *testing.T) {
 	assert.Equal(t, expectedCfg.ServiceVersion, expectedCfg.GetServiceVersion())
 	assert.Equal(t, expectedCfg.DSD, expectedCfg.GetDsdEndpoint())
 	assert.Equal(t, expectedCfg.APM, expectedCfg.GetApmEndpoint())
+
+	testParsingStringToBool := []struct {
+		input    string
+		expected bool
+		valid    bool
+	}{
+		{"true", true, true},
+		{"t", true, true},
+		{"1", true, true},
+		{"y", false, false},
+		{"yes", false, false},
+		{"false", false, true},
+		{"f", false, true},
+		{"0", false, true},
+		{"n", false, false},
+		{"no", false, false},
+		{"invalid", false, false},
+	}
+
+	for _, tt := range testParsingStringToBool {
+		t.Run(tt.input, func(t *testing.T) {
+			expectedCfg.EnableExtraProfiling = tt.input
+
+			isBool, parseFailed := strconv.ParseBool(expectedCfg.EnableExtraProfiling)
+			if parseFailed != nil && tt.valid {
+				t.Fatalf("Expected no error but got '%v'", parseFailed)
+			}
+
+			if parseFailed == nil && !tt.valid {
+				t.Fatalf("Expected an error for input '%v' but got none", tt.input)
+			}
+
+			if tt.valid && isBool != tt.expected {
+				t.Fatalf("Expected '%v' but got '%v' for input '%v'", tt.expected, isBool, tt.input)
+			}
+		})
+	}
 }


### PR DESCRIPTION
- Update JSON autogenerated tags to be the same as `mapstructure`. 
- Parse string to bool to support 2 ways of config loading: custom via `viper` pkg and vanilla