### PR TITLE
implement a new function GetTraceID

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/coopnorge/go-datadog-lib/v2/internal"
 
@@ -53,4 +54,14 @@ func OverrideTraceResourceName(sourceCtx context.Context, newResourceName string
 	ddCtx.DatadogSpan.SetTag(ext.ResourceName, newResourceName)
 
 	return nil
+}
+
+// GetTraceID returns the trace ID that the source context is carrying if present.
+func GetTraceID(sourceCtx context.Context) (string, error) {
+	ddCtx, ddExist := internal.GetContextMetadata[TraceDetails](sourceCtx, internal.TraceContextKey{})
+	if !ddExist || ddCtx.DatadogSpan == nil {
+		return "", fmt.Errorf("parent span tracer not found in context")
+	}
+	traceID := strconv.FormatUint(ddCtx.DatadogSpan.Context().TraceID(), 10)
+	return traceID, nil
 }

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -60,3 +60,15 @@ func TestOverrideTraceResourceName(t *testing.T) {
 
 	assert.Nil(t, err)
 }
+
+func TestGetTraceID(t *testing.T) {
+	ctx := context.Background()
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+
+	id, err := GetTraceID(extCtx)
+	assert.Nil(t, err)
+	assert.Equal(t, "0", id)
+}


### PR DESCRIPTION
Implementing a new function GetTraceID in order to obtain the trace ID from the current context if exists.
The test case is a bit awkward, but I could not find a way to create a new context with a span with a custom trace ID.
 