### PR TITLE
seperate existing implementation and new implementation

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -1,0 +1,18 @@
+package internal
+
+import "context"
+
+// TraceContextKey for tracer context metadata
+type TraceContextKey struct{}
+
+// ExtendedContextWithMetadata add metadata to base context
+func ExtendedContextWithMetadata[metaType any](baseCtx context.Context, metaKey any, metadata metaType) context.Context {
+	return context.WithValue(baseCtx, metaKey, metadata)
+}
+
+// GetContextMetadata will try get form context.Context metadata
+func GetContextMetadata[metaType any](baseCtx context.Context, metaKey any) (metaData metaType, isExist bool) {
+	metaData, isExist = baseCtx.Value(metaKey).(metaType)
+
+	return
+}

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -1,11 +1,72 @@
 package echo
 
 import (
+	"fmt"
+
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
+
 	"github.com/labstack/echo/v4"
-	ddEcho "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // TraceServerMiddleware for Datadog Log Integration, middleware will create span that can be used from context
 func TraceServerMiddleware() echo.MiddlewareFunc {
-	return ddEcho.Middleware()
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			if req == nil {
+				return fmt.Errorf("unable to extract request from Echo Request Context, returned nil")
+			}
+
+			opts := []ddtrace.StartSpanOption{tracer.Measured()}
+			if spanCtx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Header)); err == nil {
+				opts = append(opts, tracer.ChildOf(spanCtx))
+			}
+
+			span, spanCtx := tracer.StartSpanFromContext(req.Context(), req.RequestURI, opts...)
+			defer span.Finish()
+
+			extCtx := internal.ExtendedContextWithMetadata(
+				spanCtx,
+				internal.TraceContextKey{},
+				tracing.TraceDetails{DatadogSpan: span},
+			)
+
+			c.SetRequest(req.WithContext(extCtx))
+
+			return next(c)
+		}
+	}
+}
+
+// TraceServerMiddlewareExperimental is experimental, and will be removed in the next non-pre-release version. Used for testing a new way of setting up the middleware.
+func TraceServerMiddlewareExperimental() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			if req == nil {
+				return fmt.Errorf("unable to extract request from Echo Request Context, returned nil")
+			}
+
+			opts := []ddtrace.StartSpanOption{tracer.Measured()}
+			if spanCtx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Header)); err == nil {
+				opts = append(opts, tracer.ChildOf(spanCtx))
+			}
+
+			span, spanCtx := tracer.StartSpanFromContext(req.Context(), req.RequestURI, opts...)
+			defer span.Finish()
+
+			extCtx := internal.ExtendedContextWithMetadata(
+				spanCtx,
+				internal.TraceContextKey{},
+				tracing.TraceDetails{DatadogSpan: span},
+			)
+
+			c.SetRequest(req.WithContext(extCtx))
+
+			return next(c)
+		}
+	}
 }

--- a/middleware/echo/echo_test.go
+++ b/middleware/echo/echo_test.go
@@ -4,7 +4,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
+
 	mock_echo "github.com/coopnorge/go-datadog-lib/v2/internal/generated/mocks/labstack/echo/v4"
+
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +16,53 @@ import (
 
 func TestTraceServerMiddleware(t *testing.T) {
 	echoMiddlewareHandler := TraceServerMiddleware()
+	echoRequestHandler := func(reqCtx echo.Context) (err error) {
+		assert.NotNil(t, reqCtx.Request())
+		// Since there is mock you cannot fetch TraceDetails to verify it
+		return nil
+	}
+
+	tReq, _ := http.NewRequest(http.MethodGet, "unit.test", nil)
+
+	ctrl := gomock.NewController(t)
+	mockEchoContext := mock_echo.NewMockContext(ctrl)
+	ctrl.Finish()
+
+	mockEchoContext.EXPECT().Request().Return(tReq).MaxTimes(5)
+	mockEchoContext.EXPECT().SetRequest(gomock.Any()).MaxTimes(1)
+
+	echoMiddlewareFun := echoMiddlewareHandler(echoRequestHandler)
+	echoHandlerFunc := echoMiddlewareFun(mockEchoContext)
+
+	assert.Nil(t, echoHandlerFunc)
+}
+
+func TestTraceServerMiddlewareEchoMissingRequest(t *testing.T) {
+	echoMiddlewareHandler := TraceServerMiddleware()
+	echoRequestHandler := func(reqCtx echo.Context) (err error) {
+		assert.NotNil(t, reqCtx.Request())
+
+		meta, exist := internal.GetContextMetadata[tracing.TraceDetails](reqCtx.Request().Context(), internal.TraceContextKey{})
+		assert.True(t, exist)
+		assert.NotNil(t, meta.DatadogSpan)
+
+		return nil
+	}
+
+	ctrl := gomock.NewController(t)
+	mockEchoContext := mock_echo.NewMockContext(ctrl)
+	ctrl.Finish()
+
+	mockEchoContext.EXPECT().Request().Return(nil).MaxTimes(1)
+
+	echoMiddlewareFun := echoMiddlewareHandler(echoRequestHandler)
+	echoHandlerFunc := echoMiddlewareFun(mockEchoContext)
+
+	assert.NotNil(t, echoHandlerFunc)
+}
+
+func TestTraceServerMiddlewareExperimental(t *testing.T) {
+	echoMiddlewareHandler := TraceServerMiddlewareExperimental()
 	echoRequestHandler := func(reqCtx echo.Context) (err error) {
 		assert.NotNil(t, reqCtx.Request())
 		// Since there is mock you cannot fetch TraceDetails to verify it

--- a/middleware/grpc/grpc.go
+++ b/middleware/grpc/grpc.go
@@ -1,16 +1,51 @@
 package grpc
 
 import (
+	"context"
+
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
+
 	"google.golang.org/grpc"
 	ddGrpc "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	grpcmw "github.com/grpc-ecosystem/go-grpc-middleware"
 )
 
 // TraceUnaryServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
 func TraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return ddGrpc.UnaryServerInterceptor()
+	return func(reqCtx context.Context, req interface{}, info *grpc.UnaryServerInfo, grpcReqHandler grpc.UnaryHandler) (interface{}, error) {
+		span, spanCtx := tracer.StartSpanFromContext(reqCtx, info.FullMethod, tracer.ResourceName("grpc.request"))
+		defer span.Finish()
+
+		extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, tracing.TraceDetails{DatadogSpan: span})
+
+		return grpcReqHandler(extCtx, req)
+	}
 }
 
 // TraceStreamServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
 func TraceStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		span, spanCtx := tracer.StartSpanFromContext(ss.Context(), info.FullMethod, tracer.ResourceName("grpc.request"))
+		defer span.Finish()
+
+		extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, tracing.TraceDetails{DatadogSpan: span})
+
+		return handler(srv, &grpcmw.WrappedServerStream{
+			ServerStream:   ss,
+			WrappedContext: extCtx,
+		})
+	}
+}
+
+// TraceUnaryServerInterceptorExperimental is experimental, and will be removed in the next non-pre-release version. Used for testing a new way of setting up the interceptor.
+func TraceUnaryServerInterceptorExperimental() grpc.UnaryServerInterceptor {
+	return ddGrpc.UnaryServerInterceptor()
+}
+
+// TraceStreamServerInterceptorExperimental is experimental, and will be removed in the next non-pre-release version. Used for testing a new way of setting up the interceptor.
+func TraceStreamServerInterceptorExperimental() grpc.StreamServerInterceptor {
 	return ddGrpc.StreamServerInterceptor()
 }

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -20,7 +21,26 @@ func TestCreateNestedTrace(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
-	nestedTrace, nestedTraceErr = CreateNestedTrace(spanCtx, op, res)
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	nestedTrace, nestedTraceErr = CreateNestedTrace(extCtx, op, res)
+
+	assert.Nil(t, nestedTraceErr)
+	assert.NotNil(t, nestedTrace)
+}
+
+func TestCreateNestedTraceExperimental(t *testing.T) {
+	op := "test"
+	res := "unit"
+	ctx := context.Background()
+
+	nestedTrace, nestedTraceErr := CreateNestedTraceExperimental(ctx, op, res)
+
+	assert.Error(t, nestedTraceErr, "expected error since context not extended")
+	assert.Nil(t, nestedTrace)
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	nestedTrace, nestedTraceErr = CreateNestedTraceExperimental(spanCtx, op, res)
 
 	assert.Nil(t, nestedTraceErr)
 	assert.NotNil(t, nestedTrace)
@@ -36,7 +56,23 @@ func TestAppendUserToTrace(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
-	err = AppendUserToTrace(spanCtx, user)
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	err = AppendUserToTrace(extCtx, user)
+
+	assert.Nil(t, err)
+}
+
+func TestAppendUserToTraceExperimental(t *testing.T) {
+	user := "unit_tester"
+	ctx := context.Background()
+
+	err := AppendUserToTraceExperimental(ctx, user)
+
+	assert.Error(t, err, "expected error since context not extended")
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	err = AppendUserToTraceExperimental(spanCtx, user)
 
 	assert.Nil(t, err)
 }
@@ -51,7 +87,23 @@ func TestOverrideTraceResourceName(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
-	err = OverrideTraceResourceName(spanCtx, newRes)
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	err = OverrideTraceResourceName(extCtx, newRes)
+
+	assert.Nil(t, err)
+}
+
+func TestOverrideTraceResourceNameExperimental(t *testing.T) {
+	newRes := "unit_test"
+	ctx := context.Background()
+
+	err := OverrideTraceResourceNameExperimental(ctx, newRes)
+
+	assert.Error(t, err, "expected error since context not extended")
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	err = OverrideTraceResourceNameExperimental(spanCtx, newRes)
 
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Keeping the existing interface and implementation as is, and adding the new implmentation with prefix `Experimental` so that the new features can be tested seperatly.

I did not update log_test.go as I don't see how those functions are really testing anything.