### PR TITLE
Feature flag experimental features

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,20 @@ To preview the documentation:
 ```sh
 docker compose up techdocs
 ```
+
+## Experimental Tracing
+
+For advanced tracing capabilities and features, you can enable experimental
+tracing by setting the environment variable
+"DD_EXPERIMENTAL_TRACING_ENABLED" to "true", "TRUE", or "True".
+
+When this environment variable is set, the package utilizes an experimental
+tracing interceptor from
+[dd-trace-go](https://github.com/DataDog/dd-trace-go/blob/main/contrib/google.golang.org/grpc/server.go)
+for gRPC servers, enhancing distributed tracing capabilities.
+Additionally, for the Echo middleware, the package leverages
+the interceptor from
+[dd-trace-go Echo Middleware](https://github.com/DataDog/dd-trace-go/tree/main/contrib/labstack/echo.v4).
+
+In a future release, these experimental tracing features will become
+the default behavior, eliminating the need for the feature flag.

--- a/internal/context.go
+++ b/internal/context.go
@@ -1,0 +1,18 @@
+package internal
+
+import "context"
+
+// TraceContextKey for tracer context metadata
+type TraceContextKey struct{}
+
+// ExtendedContextWithMetadata add metadata to base context
+func ExtendedContextWithMetadata[metaType any](baseCtx context.Context, metaKey any, metadata metaType) context.Context {
+	return context.WithValue(baseCtx, metaKey, metadata)
+}
+
+// GetContextMetadata will try get form context.Context metadata
+func GetContextMetadata[metaType any](baseCtx context.Context, metaKey any) (metaData metaType, isExist bool) {
+	metaData, isExist = baseCtx.Value(metaKey).(metaType)
+
+	return
+}

--- a/internal/env.go
+++ b/internal/env.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 )
 
+// ExperimentalTracingEnabled is the environment variable key determining if experimental tracing should be enabled
 const ExperimentalTracingEnabled = "DD_EXPERIMENTAL_TRACING_ENABLED"
 
+// IsExperimentalTracingEnabled checks if experimental tracing is enabled
 func IsExperimentalTracingEnabled() bool {
-	if strings.ToLower(os.Getenv(ExperimentalTracingEnabled)) == "true" {
-		return true
-	}
-	return false
+	return strings.ToLower(os.Getenv(ExperimentalTracingEnabled)) == "true"
 }

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,0 +1,15 @@
+package internal
+
+import (
+	"os"
+	"strings"
+)
+
+const ExperimentalTracingEnabled = "DD_EXPERIMENTAL_TRACING_ENABLED"
+
+func IsExperimentalTracingEnabled() bool {
+	if strings.ToLower(os.Getenv(ExperimentalTracingEnabled)) == "true" {
+		return true
+	}
+	return false
+}

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coopnorge/go-datadog-lib/v2/tracing"
 
 	"github.com/labstack/echo/v4"
+	ddEcho "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -50,30 +51,5 @@ func traceServerMiddlewareLegacy() echo.MiddlewareFunc {
 
 // TraceServerMiddlewareExperimental is experimental, and will be removed in the next non-pre-release version. Used for testing a new way of setting up the middleware.
 func traceServerMiddlewareExperimental() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			req := c.Request()
-			if req == nil {
-				return fmt.Errorf("unable to extract request from Echo Request Context, returned nil")
-			}
-
-			opts := []ddtrace.StartSpanOption{tracer.Measured()}
-			if spanCtx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Header)); err == nil {
-				opts = append(opts, tracer.ChildOf(spanCtx))
-			}
-
-			span, spanCtx := tracer.StartSpanFromContext(req.Context(), req.RequestURI, opts...)
-			defer span.Finish()
-
-			extCtx := internal.ExtendedContextWithMetadata(
-				spanCtx,
-				internal.TraceContextKey{},
-				tracing.TraceDetails{DatadogSpan: span},
-			)
-
-			c.SetRequest(req.WithContext(extCtx))
-
-			return next(c)
-		}
-	}
+	return ddEcho.Middleware()
 }

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -1,11 +1,79 @@
 package echo
 
 import (
+	"fmt"
+
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
+
 	"github.com/labstack/echo/v4"
-	ddEcho "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // TraceServerMiddleware for Datadog Log Integration, middleware will create span that can be used from context
 func TraceServerMiddleware() echo.MiddlewareFunc {
-	return ddEcho.Middleware()
+	if internal.IsExperimentalTracingEnabled() {
+		return traceServerMiddlewareExperimental()
+	}
+	return traceServerMiddlewareLegacy()
+}
+
+func traceServerMiddlewareLegacy() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			if req == nil {
+				return fmt.Errorf("unable to extract request from Echo Request Context, returned nil")
+			}
+
+			opts := []ddtrace.StartSpanOption{tracer.Measured()}
+			if spanCtx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Header)); err == nil {
+				opts = append(opts, tracer.ChildOf(spanCtx))
+			}
+
+			span, spanCtx := tracer.StartSpanFromContext(req.Context(), req.RequestURI, opts...)
+			defer span.Finish()
+
+			extCtx := internal.ExtendedContextWithMetadata(
+				spanCtx,
+				internal.TraceContextKey{},
+				tracing.TraceDetails{DatadogSpan: span},
+			)
+
+			c.SetRequest(req.WithContext(extCtx))
+
+			return next(c)
+		}
+	}
+}
+
+// TraceServerMiddlewareExperimental is experimental, and will be removed in the next non-pre-release version. Used for testing a new way of setting up the middleware.
+func traceServerMiddlewareExperimental() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			if req == nil {
+				return fmt.Errorf("unable to extract request from Echo Request Context, returned nil")
+			}
+
+			opts := []ddtrace.StartSpanOption{tracer.Measured()}
+			if spanCtx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Header)); err == nil {
+				opts = append(opts, tracer.ChildOf(spanCtx))
+			}
+
+			span, spanCtx := tracer.StartSpanFromContext(req.Context(), req.RequestURI, opts...)
+			defer span.Finish()
+
+			extCtx := internal.ExtendedContextWithMetadata(
+				spanCtx,
+				internal.TraceContextKey{},
+				tracing.TraceDetails{DatadogSpan: span},
+			)
+
+			c.SetRequest(req.WithContext(extCtx))
+
+			return next(c)
+		}
+	}
 }

--- a/middleware/grpc/grpc.go
+++ b/middleware/grpc/grpc.go
@@ -1,16 +1,61 @@
 package grpc
 
 import (
+	"context"
+
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
+	grpcmw "github.com/grpc-ecosystem/go-grpc-middleware"
 	"google.golang.org/grpc"
 	ddGrpc "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // TraceUnaryServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
 func TraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return ddGrpc.UnaryServerInterceptor()
+	if internal.IsExperimentalTracingEnabled() {
+		return traceUnaryServerInterceptorExperimental()
+	}
+	return traceUnaryServerInterceptorLegacy()
 }
 
 // TraceStreamServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
 func TraceStreamServerInterceptor() grpc.StreamServerInterceptor {
+	if internal.IsExperimentalTracingEnabled() {
+		return traceStreamServerInterceptorExperimental()
+	}
+	return traceStreamServerInterceptorLegacy()
+}
+
+func traceUnaryServerInterceptorLegacy() grpc.UnaryServerInterceptor {
+	return func(reqCtx context.Context, req interface{}, info *grpc.UnaryServerInfo, grpcReqHandler grpc.UnaryHandler) (interface{}, error) {
+		span, spanCtx := tracer.StartSpanFromContext(reqCtx, info.FullMethod, tracer.ResourceName("grpc.request"))
+		defer span.Finish()
+
+		extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, tracing.TraceDetails{DatadogSpan: span})
+
+		return grpcReqHandler(extCtx, req)
+	}
+}
+
+func traceUnaryServerInterceptorExperimental() grpc.UnaryServerInterceptor {
+	return ddGrpc.UnaryServerInterceptor()
+}
+
+func traceStreamServerInterceptorLegacy() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		span, spanCtx := tracer.StartSpanFromContext(ss.Context(), info.FullMethod, tracer.ResourceName("grpc.request"))
+		defer span.Finish()
+
+		extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, tracing.TraceDetails{DatadogSpan: span})
+
+		return handler(srv, &grpcmw.WrappedServerStream{
+			ServerStream:   ss,
+			WrappedContext: extCtx,
+		})
+	}
+}
+
+func traceStreamServerInterceptorExperimental() grpc.StreamServerInterceptor {
 	return ddGrpc.StreamServerInterceptor()
 }

--- a/middleware/grpc/grpc_test.go
+++ b/middleware/grpc/grpc_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -13,8 +15,31 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
-func TestTraceUnaryServerInterceptor(t *testing.T) {
-	grpcUnaryMW := TraceUnaryServerInterceptor()
+func TestTraceUnaryServerInterceptorLegacy(t *testing.T) {
+	grpcUnaryMW := traceUnaryServerInterceptorLegacy()
+	grpcUnaryHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		meta, exist := internal.GetContextMetadata[tracing.TraceDetails](ctx, internal.TraceContextKey{})
+		assert.True(t, exist)
+		assert.NotNil(t, meta.DatadogSpan)
+
+		return nil, nil
+	}
+
+	tCtx := context.Background()
+	tReq, _ := http.NewRequest(http.MethodGet, "unit.test", nil)
+	resp, err := grpcUnaryMW(
+		tCtx,
+		tReq,
+		&grpc.UnaryServerInfo{FullMethod: "test"},
+		grpcUnaryHandler,
+	)
+
+	assert.Nil(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestTraceUnaryServerInterceptorExperimental(t *testing.T) {
+	grpcUnaryMW := traceUnaryServerInterceptorExperimental()
 	grpcUnaryHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		span, exists := tracer.SpanFromContext(ctx)
 		assert.True(t, exists)
@@ -40,15 +65,15 @@ type streamServerInterceptorTestSuite struct {
 	*testpb.InterceptorTestSuite
 }
 
-type testPingService struct {
+type testPingServiceLegacy struct {
 	*testpb.TestPingService
 	t *testing.T
 }
 
-func (s *testPingService) PingList(_ *testpb.PingListRequest, stream testpb.TestService_PingListServer) error {
-	span, exists := tracer.SpanFromContext(stream.Context())
-	assert.True(s.t, exists)
-	assert.NotNil(s.t, span)
+func (s *testPingServiceLegacy) PingList(_ *testpb.PingListRequest, stream testpb.TestService_PingListServer) error {
+	meta, exist := internal.GetContextMetadata[tracing.TraceDetails](stream.Context(), internal.TraceContextKey{})
+	assert.True(s.t, exist)
+	assert.NotNil(s.t, meta.DatadogSpan)
 	return nil
 }
 
@@ -57,16 +82,42 @@ func (s *streamServerInterceptorTestSuite) TestPingStream() {
 	s.Client.PingList(ctx, &testpb.PingListRequest{})
 }
 
-func TestTraceStreamServerInterceptor(t *testing.T) {
+func TestTraceStreamServerInterceptorLegacy(t *testing.T) {
 	s := &streamServerInterceptorTestSuite{
 		&testpb.InterceptorTestSuite{
-			TestService: &testPingService{
+			TestService: &testPingServiceLegacy{
 				t: t,
 			},
 		},
 	}
 	s.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
-		grpc.StreamInterceptor(TraceStreamServerInterceptor()),
+		grpc.StreamInterceptor(traceStreamServerInterceptorLegacy()),
+	}
+	suite.Run(t, s)
+}
+
+type testPingServiceExperimental struct {
+	*testpb.TestPingService
+	t *testing.T
+}
+
+func (s *testPingServiceExperimental) PingList(_ *testpb.PingListRequest, stream testpb.TestService_PingListServer) error {
+	span, exists := tracer.SpanFromContext(stream.Context())
+	assert.True(s.t, exists)
+	assert.NotNil(s.t, span)
+	return nil
+}
+
+func TestTraceStreamServerInterceptorExperimental(t *testing.T) {
+	s := &streamServerInterceptorTestSuite{
+		&testpb.InterceptorTestSuite{
+			TestService: &testPingServiceExperimental{
+				t: t,
+			},
+		},
+	}
+	s.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc.StreamInterceptor(traceStreamServerInterceptorExperimental()),
 	}
 	suite.Run(t, s)
 }

--- a/tracing/log.go
+++ b/tracing/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
 	"github.com/coopnorge/go-logger"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -27,7 +28,11 @@ func LogFieldsWithTrace(sourceCtx context.Context, severity logger.Level, messag
 func getMessageToLog(ctx context.Context, message string) string {
 	var messageToLog string
 
-	span, exists := tracer.SpanFromContext(ctx)
+	ddCtx, exists := internal.GetContextMetadata[TraceDetails](ctx, internal.TraceContextKey{})
+	span := ddCtx.DatadogSpan
+	if internal.IsExperimentalTracingEnabled() {
+		span, exists = tracer.SpanFromContext(ctx)
+	}
 	if exists {
 		messageToLog = fmt.Sprintf("%s %v dd.lang=go", message, span)
 	} else {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -19,8 +20,8 @@ type (
 
 // CreateNestedTrace will fork parent tracer to attach to parent one with new operation and resource from sourceCtx
 func CreateNestedTrace(sourceCtx context.Context, operation, resource string) (ddtrace.Span, error) {
-	span, exists := tracer.SpanFromContext(sourceCtx)
-	if !exists || span == nil {
+	span := getSpanFromContext(sourceCtx)
+	if span == nil {
 		return nil, fmt.Errorf("inheritance failed, parent span tracer not found in context")
 	}
 
@@ -31,8 +32,8 @@ func CreateNestedTrace(sourceCtx context.Context, operation, resource string) (d
 
 // AppendUserToTrace includes identifier of user that would be attached to span in datadog
 func AppendUserToTrace(sourceCtx context.Context, user string) error {
-	span, exists := tracer.SpanFromContext(sourceCtx)
-	if !exists || span == nil {
+	span := getSpanFromContext(sourceCtx)
+	if span == nil {
 		return fmt.Errorf("parent span tracer not found in context")
 	}
 
@@ -43,12 +44,26 @@ func AppendUserToTrace(sourceCtx context.Context, user string) error {
 
 // OverrideTraceResourceName set custom resource name for traced span aka SQL Query, Request, I/O etc
 func OverrideTraceResourceName(sourceCtx context.Context, newResourceName string) error {
-	span, exists := tracer.SpanFromContext(sourceCtx)
-	if !exists || span == nil {
+	span := getSpanFromContext(sourceCtx)
+	if span == nil {
 		return fmt.Errorf("parent span tracer not found in context")
 	}
 
 	span.SetTag(ext.ResourceName, newResourceName)
 
 	return nil
+}
+
+func getSpanFromContext(ctx context.Context) tracer.Span {
+	if internal.IsExperimentalTracingEnabled() {
+		if span, exists := tracer.SpanFromContext(ctx); exists {
+			return span
+		}
+		return nil
+	}
+	ddCtx, ddExist := internal.GetContextMetadata[TraceDetails](ctx, internal.TraceContextKey{})
+	if !ddExist || ddCtx.DatadogSpan == nil {
+		return nil
+	}
+	return ddCtx.DatadogSpan
 }

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -2,8 +2,10 @@ package tracing
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	"github.com/coopnorge/go-datadog-lib/v2/internal"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -20,6 +22,29 @@ func TestCreateNestedTrace(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	nestedTrace, nestedTraceErr = CreateNestedTrace(extCtx, op, res)
+
+	assert.Nil(t, nestedTraceErr)
+	assert.NotNil(t, nestedTrace)
+}
+
+func TestCreateNestedTraceExperimental(t *testing.T) {
+	op := "test"
+	res := "unit"
+	ctx := context.Background()
+
+	nestedTrace, nestedTraceErr := CreateNestedTrace(ctx, op, res)
+
+	assert.Error(t, nestedTraceErr, "expected error since context not extended")
+	assert.Nil(t, nestedTrace)
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	os.Setenv(internal.ExperimentalTracingEnabled, "true")
+	defer func() {
+		os.Setenv(internal.ExperimentalTracingEnabled, "")
+	}()
 	nestedTrace, nestedTraceErr = CreateNestedTrace(spanCtx, op, res)
 
 	assert.Nil(t, nestedTraceErr)
@@ -36,6 +61,26 @@ func TestAppendUserToTrace(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	err = AppendUserToTrace(extCtx, user)
+
+	assert.Nil(t, err)
+}
+
+func TestAppendUserToTraceExperimental(t *testing.T) {
+	user := "unit_tester"
+	ctx := context.Background()
+
+	err := AppendUserToTrace(ctx, user)
+
+	assert.Error(t, err, "expected error since context not extended")
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	os.Setenv(internal.ExperimentalTracingEnabled, "true")
+	defer func() {
+		os.Setenv(internal.ExperimentalTracingEnabled, "")
+	}()
 	err = AppendUserToTrace(spanCtx, user)
 
 	assert.Nil(t, err)
@@ -51,6 +96,26 @@ func TestOverrideTraceResourceName(t *testing.T) {
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
+	extCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+	err = OverrideTraceResourceName(extCtx, newRes)
+
+	assert.Nil(t, err)
+}
+
+func TestOverrideTraceResourceNameExperimental(t *testing.T) {
+	newRes := "unit_test"
+	ctx := context.Background()
+
+	err := OverrideTraceResourceName(ctx, newRes)
+
+	assert.Error(t, err, "expected error since context not extended")
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+	os.Setenv(internal.ExperimentalTracingEnabled, "true")
+	defer func() {
+		os.Setenv(internal.ExperimentalTracingEnabled, "")
+	}()
 	err = OverrideTraceResourceName(spanCtx, newRes)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
Pull reguest for merging into branch `distributed_tracing` ref pr: https://github.com/coopnorge/go-datadog-lib/pull/155

Feature flagging the new features while keeping the old implementation.
only if env var `DD_EXPERIMENTAL_TRACING_ENABLED` is set to `True` you will get the new interceptor implementation.
This will make it possible to change between versions in different environments.