### PR TITLE
Add generic traced executioner for lambda function to record Datadog tracer spans

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -74,7 +74,7 @@ func ExecuteWithTrace[T any](ctx context.Context, callable func() (T, error), so
 
 	// NOTE: close only if context was given with Datadog metadata.
 	if traceSpanErr == nil {
-		traceSpan.Finish()
+		traceSpan.Finish(ddtrace.WithError(execErr))
 	}
 
 	return execResp, execErr

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -74,7 +74,7 @@ func ExecuteWithTrace[T any](ctx context.Context, callable func() (T, error), so
 
 	// NOTE: close only if context was given with Datadog metadata.
 	if traceSpanErr == nil {
-		traceSpan.Finish(ddtrace.WithError(execErr))
+		traceSpan.Finish(tracer.WithError(execErr))
 	}
 
 	return execResp, execErr


### PR DESCRIPTION
Allows do this in a simple way:
![image](https://github.com/coopnorge/go-datadog-lib/assets/13393702/40b5d83c-d858-41bc-9d64-f0dea4a40a60)
