### PR TITLE
add context to ExecuteWithTrace's callable function

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -67,10 +67,11 @@ func OverrideTraceResourceName(sourceCtx context.Context, newResourceName string
 //	    "GetMyModel.SQL",
 //	    "GetMyModel",
 //	)
-func ExecuteWithTrace[T any](ctx context.Context, callable func() (T, error), source, op string) (T, error) {
+func ExecuteWithTrace[T any](ctx context.Context, callable func(context.Context) (T, error), source, op string) (T, error) {
 	traceSpan, traceSpanErr := CreateNestedTrace(ctx, fmt.Sprintf("%s.%s", source, op), op)
+	traceCtx := internal.ExtendedContextWithMetadata(ctx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: traceSpan})
 
-	execResp, execErr := callable()
+	execResp, execErr := callable(traceCtx)
 
 	// NOTE: close only if context was given with Datadog metadata.
 	if traceSpanErr == nil {

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -3,10 +3,13 @@ package tracing
 import (
 	"context"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/coopnorge/go-datadog-lib/v2/internal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -123,17 +126,39 @@ func TestOverrideTraceResourceNameExperimental(t *testing.T) {
 
 func TestExecuteWithTrace(t *testing.T) {
 	ctx := context.Background()
+
+	// Start Datadog tracer, so that we don't create NoopSpans.
+	mocktracer := mocktracer.Start()
+
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
 
 	ddCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
 
 	isCallableCalled := false
-	callableUnit := func() (bool, error) {
+	callableUnit := func(ctx context.Context) (bool, error) {
+		metadata, ok := internal.GetContextMetadata[TraceDetails](ctx, internal.TraceContextKey{})
+		require.True(t, ok)
+		assert.Equal(t, span.Context().TraceID(), metadata.DatadogSpan.Context().TraceID(), "The TraceID of both spans should be the same (same root)")
+		assert.NotEqual(t, span.Context().SpanID(), metadata.DatadogSpan.Context().SpanID(), "The SpanID should be different, and it should be a child-span")
 		return !isCallableCalled, nil
 	}
 
 	execRes, execErr := ExecuteWithTrace[bool](ddCtx, callableUnit, "unit.test", "test")
 	assert.NoError(t, execErr, "expected context with Datadog tracer context")
 	assert.True(t, execRes, "expected response of ExecuteWithTrace to be true")
+
+	span.Finish() // Finish the original span
+
+	require.Equal(t, 0, len(mocktracer.OpenSpans()))
+	spans := mocktracer.FinishedSpans()
+	sort.Slice(spans, func(i, j int) bool {
+		return spans[i].StartTime().Before(spans[j].StartTime())
+	})
+	require.Equal(t, 2, len(spans))
+
+	assert.NotEqual(t, uint64(0), spans[0].SpanID())
+	assert.NotEqual(t, uint64(0), spans[1].SpanID())
+	assert.Equal(t, uint64(0), spans[0].ParentID())
+	assert.Equal(t, spans[0].SpanID(), spans[1].ParentID(), "spans[1] should be child of spans[0]")
 }


### PR DESCRIPTION
An extension of the suggestion in #191.

Note that the target branch of this PR is the branch for #191.