### PR TITLE
feat: Exposed GetSpanFromContext so that dev can trace, hard to trace func

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,10 +55,6 @@ func (d DatadogConfig) IsDataDogConfigValid() bool {
 	return true
 }
 
-func (d DatadogConfig) Validate() (bool, error) {
-	return d.IsDataDogConfigValid(), nil
-}
-
 // GetEnv where application is executed, dev, production, staging etc
 func (d DatadogConfig) GetEnv() string {
 	return d.Env

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,10 @@ func (d DatadogConfig) IsDataDogConfigValid() bool {
 	return true
 }
 
+func (d DatadogConfig) Validate() (bool, error) {
+	return d.IsDataDogConfigValid(), nil
+}
+
 // GetEnv where application is executed, dev, production, staging etc
 func (d DatadogConfig) GetEnv() string {
 	return d.Env

--- a/tracing/noop_span.go
+++ b/tracing/noop_span.go
@@ -1,0 +1,35 @@
+package tracing
+
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+
+type (
+	noopSpan struct{}
+)
+
+var _ ddtrace.Span = (*noopSpan)(nil)
+
+// BaggageItem implements ddtrace.Span.
+func (*noopSpan) BaggageItem(key string) string {
+	return ""
+}
+
+// Context implements ddtrace.Span.
+func (*noopSpan) Context() ddtrace.SpanContext {
+	return &noopSpanContext{}
+}
+
+// Finish implements ddtrace.Span.
+func (*noopSpan) Finish(opts ...ddtrace.FinishOption) {
+}
+
+// SetBaggageItem implements ddtrace.Span.
+func (*noopSpan) SetBaggageItem(key string, val string) {
+}
+
+// SetOperationName implements ddtrace.Span.
+func (*noopSpan) SetOperationName(operationName string) {
+}
+
+// SetTag implements ddtrace.Span.
+func (*noopSpan) SetTag(key string, value interface{}) {
+}

--- a/tracing/noop_span.go
+++ b/tracing/noop_span.go
@@ -9,7 +9,7 @@ type (
 var _ ddtrace.Span = (*noopSpan)(nil)
 
 // BaggageItem implements ddtrace.Span.
-func (*noopSpan) BaggageItem(key string) string {
+func (*noopSpan) BaggageItem(_ string) string {
 	return ""
 }
 
@@ -19,17 +19,17 @@ func (*noopSpan) Context() ddtrace.SpanContext {
 }
 
 // Finish implements ddtrace.Span.
-func (*noopSpan) Finish(opts ...ddtrace.FinishOption) {
+func (*noopSpan) Finish(_ ...ddtrace.FinishOption) {
 }
 
 // SetBaggageItem implements ddtrace.Span.
-func (*noopSpan) SetBaggageItem(key string, val string) {
+func (*noopSpan) SetBaggageItem(_ string, _ string) {
 }
 
 // SetOperationName implements ddtrace.Span.
-func (*noopSpan) SetOperationName(operationName string) {
+func (*noopSpan) SetOperationName(_ string) {
 }
 
 // SetTag implements ddtrace.Span.
-func (*noopSpan) SetTag(key string, value interface{}) {
+func (*noopSpan) SetTag(_ string, _ interface{}) {
 }

--- a/tracing/noop_span_context.go
+++ b/tracing/noop_span_context.go
@@ -1,0 +1,23 @@
+package tracing
+
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+
+type (
+	noopSpanContext struct{}
+)
+
+var _ ddtrace.SpanContext = (*noopSpanContext)(nil)
+
+// ForeachBaggageItem implements ddtrace.SpanContext.
+func (*noopSpanContext) ForeachBaggageItem(handler func(k string, v string) bool) {
+}
+
+// SpanID implements ddtrace.SpanContext.
+func (*noopSpanContext) SpanID() uint64 {
+	return 0
+}
+
+// TraceID implements ddtrace.SpanContext.
+func (*noopSpanContext) TraceID() uint64 {
+	return 0
+}

--- a/tracing/noop_span_context.go
+++ b/tracing/noop_span_context.go
@@ -9,7 +9,7 @@ type (
 var _ ddtrace.SpanContext = (*noopSpanContext)(nil)
 
 // ForeachBaggageItem implements ddtrace.SpanContext.
-func (*noopSpanContext) ForeachBaggageItem(handler func(k string, v string) bool) {
+func (*noopSpanContext) ForeachBaggageItem(_ func(k string, v string) bool) {
 }
 
 // SpanID implements ddtrace.SpanContext.

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -44,6 +44,7 @@ func OverrideTraceResourceName(sourceCtx context.Context, newResourceName string
 	return nil
 }
 
+// GetSpanFromContext returns span from context or noopSpan if ddContext cannot be found
 func GetSpanFromContext(ctx context.Context) tracer.Span {
 	if internal.IsExperimentalTracingEnabled() {
 		if span, exists := tracer.SpanFromContext(ctx); exists {

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -17,8 +17,8 @@ func TestCreateNestedTrace(t *testing.T) {
 
 	nestedTrace, nestedTraceErr := CreateNestedTrace(ctx, op, res)
 
-	assert.Error(t, nestedTraceErr, "expected error since context not extended")
-	assert.Nil(t, nestedTrace)
+	assert.Nil(t, nestedTraceErr)
+	assert.NotNil(t, nestedTrace)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
@@ -36,8 +36,8 @@ func TestCreateNestedTraceExperimental(t *testing.T) {
 
 	nestedTrace, nestedTraceErr := CreateNestedTrace(ctx, op, res)
 
-	assert.Error(t, nestedTraceErr, "expected error since context not extended")
-	assert.Nil(t, nestedTrace)
+	assert.Nil(t, nestedTraceErr)
+	assert.NotNil(t, nestedTrace)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
@@ -57,7 +57,7 @@ func TestAppendUserToTrace(t *testing.T) {
 
 	err := AppendUserToTrace(ctx, user)
 
-	assert.Error(t, err, "expected error since context not extended")
+	assert.Nil(t, err)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
@@ -73,7 +73,7 @@ func TestAppendUserToTraceExperimental(t *testing.T) {
 
 	err := AppendUserToTrace(ctx, user)
 
-	assert.Error(t, err, "expected error since context not extended")
+	assert.Nil(t, err)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
@@ -92,7 +92,7 @@ func TestOverrideTraceResourceName(t *testing.T) {
 
 	err := OverrideTraceResourceName(ctx, newRes)
 
-	assert.Error(t, err, "expected error since context not extended")
+	assert.Nil(t, err)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()
@@ -108,7 +108,7 @@ func TestOverrideTraceResourceNameExperimental(t *testing.T) {
 
 	err := OverrideTraceResourceName(ctx, newRes)
 
-	assert.Error(t, err, "expected error since context not extended")
+	assert.Nil(t, err)
 
 	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
 	defer span.Finish()


### PR DESCRIPTION
We started with #191.

The opaque abstraction although shields the devs from details of datadog,
seems to be creating more issue.

We start with supporting tracing for function with 1 argument, and then
more might follow.

Rather than that, an alternative solution is to expose GetSpanFromContext
which will allow the devs to get the span and then trace to their heart's
content. But, this also means, the abstraction is now leaky.

I have also introduced noopSpan and noopContext so that devs do not have
to nil check the span everywhere.
