### PR TITLE
add ExecuteWithTrace to easily capture any errors in the span

### DIFF
--- a/tracing/noop.go
+++ b/tracing/noop.go
@@ -1,0 +1,42 @@
+package tracing
+
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+
+// noopSpan and noopSpanContext is duplicated from "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal/globaltracer.go"
+
+var _ ddtrace.Span = (*noopSpan)(nil)
+
+// noopSpan is an implementation of ddtrace.Span that is a no-op.
+type noopSpan struct{}
+
+// SetTag implements ddtrace.Span.
+func (noopSpan) SetTag(_ string, _ interface{}) {}
+
+// SetOperationName implements ddtrace.Span.
+func (noopSpan) SetOperationName(_ string) {}
+
+// BaggageItem implements ddtrace.Span.
+func (noopSpan) BaggageItem(_ string) string { return "" }
+
+// SetBaggageItem implements ddtrace.Span.
+func (noopSpan) SetBaggageItem(_, _ string) {}
+
+// Finish implements ddtrace.Span.
+func (noopSpan) Finish(_ ...ddtrace.FinishOption) {}
+
+// Context implements ddtrace.Span.
+func (noopSpan) Context() ddtrace.SpanContext { return noopSpanContext{} }
+
+var _ ddtrace.SpanContext = (*noopSpanContext)(nil)
+
+// noopSpanContext is an implementation of ddtrace.SpanContext that is a no-op.
+type noopSpanContext struct{}
+
+// SpanID implements ddtrace.SpanContext.
+func (noopSpanContext) SpanID() uint64 { return 0 }
+
+// TraceID implements ddtrace.SpanContext.
+func (noopSpanContext) TraceID() uint64 { return 0 }
+
+// ForeachBaggageItem implements ddtrace.SpanContext.
+func (noopSpanContext) ForeachBaggageItem(_ func(k, v string) bool) {}

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/coopnorge/go-datadog-lib/v2/internal"
@@ -188,4 +189,43 @@ func TestStartChildSpan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecuteWithTrace(t *testing.T) {
+	ctx := context.Background()
+
+	// Start Datadog tracer, so that we don't create NoopSpans.
+	mocktracer := mocktracer.Start()
+
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "test", tracer.ResourceName("UnitTest"))
+	defer span.Finish()
+
+	ddCtx := internal.ExtendedContextWithMetadata(spanCtx, internal.TraceContextKey{}, TraceDetails{DatadogSpan: span})
+
+	var execRes bool
+	callableUnit := func(ctx context.Context) error {
+		metadata, ok := internal.GetContextMetadata[TraceDetails](ctx, internal.TraceContextKey{})
+		require.True(t, ok)
+		assert.Equal(t, span.Context().TraceID(), metadata.DatadogSpan.Context().TraceID(), "The TraceID of both spans should be the same (same root)")
+		assert.NotEqual(t, span.Context().SpanID(), metadata.DatadogSpan.Context().SpanID(), "The SpanID should be different, and it should be a child-span")
+		execRes = true
+		return nil
+	}
+	execErr := ExecuteWithTrace(ddCtx, callableUnit, "unit.test", "test")
+	assert.NoError(t, execErr, "expected context with Datadog tracer context")
+	assert.True(t, execRes, "expected response of ExecuteWithTrace to be true")
+
+	span.Finish() // Finish the original span
+
+	require.Equal(t, 0, len(mocktracer.OpenSpans()))
+	spans := mocktracer.FinishedSpans()
+	sort.Slice(spans, func(i, j int) bool {
+		return spans[i].StartTime().Before(spans[j].StartTime())
+	})
+	require.Equal(t, 2, len(spans))
+
+	assert.NotEqual(t, uint64(0), spans[0].SpanID())
+	assert.NotEqual(t, uint64(0), spans[1].SpanID())
+	assert.Equal(t, uint64(0), spans[0].ParentID())
+	assert.Equal(t, spans[0].SpanID(), spans[1].ParentID(), "spans[1] should be child of spans[0]")
 }


### PR DESCRIPTION
Stacked PR on top of #196.

Note: My advice is to NOT merge this PR, but rather work directly with the solution (maybe modified to also return a ctx) from #196.

The example function mentioned in #191 becomes:

```go
func (r *Repository) GetFooBar(ctx context.Context, id uint) (MyModel, error) {
	var execRes *MyModel
	getMyModel := func(ctx context.Context) error {
		model, err := r.GetMyModel(ctx, id)
		if err != nil {
			return err
		}
		execRes = model
		return nil
	}

	err := coopDDTrace.ExecuteWithTrace(ctx, getMyModel, "GetMyModel.SQL", "GetMyModel")

	return execRes, err
}
```

or

```go
func (r *Repository) GetFooBar(ctx context.Context, id uint) (MyModel, error) {
	var execRes *MyModel
	err := coopDDTrace.ExecuteWithTrace(ctx, func(ctx context.Context) error {
		model, err := r.GetMyModel(ctx, id)
		if err != nil {
			return err
		}
		execRes = model
		return nil
	}, "GetMyModel.SQL", "GetMyModel")

	return execRes, err
}
```

Note that this version does not have any returns other than the error, which would allow for 0, 1, or several return values without creating new functions.

Another alternative is to create multiple version of `ExecuteWIthTrace`, for each number of return values we want to support:
```go
func (r *Repository) DoSomething(ctx context.Context, id uint) error {
	myFunction := func(ctx context.Context) error {
		return doSomeExecution(ctx, id)
	}

	err := coopDDTrace.ExecuteWithTrace0(ctx, myFunction, "DoSomething.SQL", "DoSomething")

	return err
}

func (r *Repository) GetFooBar(ctx context.Context, id uint) (*MyModel, error) {
	getMyModel := func(ctx context.Context) (*MyModel, error) {
		return r.GetMyModel(ctx, id)
	}

	execRes,err := coopDDTrace.ExecuteWithTrace1[*MyModel](ctx, getMyModel, "GetMyModel.SQL", "GetMyModel")

	return execRes, err
}

func (r *Repository) GetFooBarBaz(ctx context.Context, id uint) (*MyModel, error) {
	getMyBazModel := func(ctx context.Context) (*MyModel, bool, error) {
		return r.GetMyBazModel(ctx, id)
	}

	execRes, somethingHappened, err := coopDDTrace.ExecuteWithTrace2[*MyModel,bool](ctx, getMyBazModel, "GetFooBarBaz.SQL", "GetFooBarBaz")

	if somethingHappened {
		// do something
	}

	return execRes, err
}
```

I don't really like any of these versions, and much rather prefer to work directly with the trace, and not let the trace-library have to deal with how many input- or output-parameters you have:
```go
func (r *Repository) GetFooBar(ctx context.Context, id uint) (MyModel, error) {
	span := coopDDTrace.CreateChildSpan(ctx, "GetMyModel.SQL", "GetMyModel")
	ctx = coopDDTrace.AddSpanToContext(ctx, span)
	defer span.Finish() // span.Finish should be idempotent, so it's safe to call multiple times.

	model, err := r.GetMyModel(ctx, id)
	if err != nil {
		span.Finish(tracer.WithError(err)) // or probably coopDDTrace.WithError(err)
		return nil, err
	}

	return model, nil
}
```

Or even shorter, if we return context.Context from CreateChildSpan:
```go
func (r *Repository) GetFooBar(ctx context.Context, id uint) (MyModel, error) {
	ctx, span := coopDDTrace.CreateChildSpan(ctx, "GetMyModel.SQL", "GetMyModel")
	defer span.Finish() // span.Finish should be idempotent, so it's safe to call multiple times.

	model, err := r.GetMyModel(ctx, id)
	if err != nil {
		span.Finish(tracer.WithError(err)) // or probably coopDDTrace.WithError(err)
		return nil, err
	}

	return model, nil
}
```