### PR TITLE
chore: Add missing GHA workflow permissions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -47,6 +47,7 @@ jobs:
       contents: read
       id-token: write
       packages: read
+      pull-requests: read
     name: TechDocs
     uses: coopnorge/github-workflow-techdocs/.github/workflows/techdocs.yaml@v0
 


### PR DESCRIPTION
`coopnorge/github-workflow-techdocs/.github/workflows/techdocs.yaml@v0` now
requires `pull-requests: read`.
