### PR TITLE
feat: Add Datadog hook for go-logger lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.4.0
-	github.com/coopnorge/go-logger v0.5.0
+	github.com/coopnorge/go-logger v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/labstack/echo/v4 v4.11.4

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coopnorge/go-logger v0.5.0 h1:1/wOq6grGTH2+G4t7rZilF5V78zSV+8WsVLBkYBd9cw=
-github.com/coopnorge/go-logger v0.5.0/go.mod h1:flmFNGUZiwmi0bb/eEBEIC2ce3kVvru1ExSKXJlrVxs=
+github.com/coopnorge/go-logger v0.6.0 h1:xIdBu1ITOwVy1NiJMhWgZLbO5GGJCWMfbd9a7jwZI2A=
+github.com/coopnorge/go-logger v0.6.0/go.mod h1:1TOC146ZNCxtputAVHTCEFir37tuNZgqIZv5u8JnLmE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tracelogger/hook.go
+++ b/tracelogger/hook.go
@@ -1,0 +1,31 @@
+package tracelogger
+
+import (
+	"github.com/coopnorge/go-logger"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// DDContextLogHook ensures that any span in the log context is correlated to log output.
+type DDContextLogHook struct{}
+
+// Fire implements logger.Hook interface, attaches trace and span details found in entry context
+func (d *DDContextLogHook) Fire(he *logger.HookEntry) (bool, error) {
+	ctx := he.Context
+	if ctx == nil {
+		return false, nil
+	}
+	span, found := tracer.SpanFromContext(he.Context)
+	if !found {
+		return false, nil
+	}
+	he.Data["dd.trace_id"] = span.Context().TraceID()
+	he.Data["dd.span_id"] = span.Context().SpanID()
+	return true, nil
+}
+
+// NewHook will create a new Hook compatible with go-logger,
+// to automatically extract Span/Trace information from the Log-entry's context.Context,
+// and add them as fields to the log-message.
+func NewHook() logger.Hook {
+	return &DDContextLogHook{}
+}


### PR DESCRIPTION
If the hook is added to the go-logger lib, and then a log-message is logged with `logger.WithContext(ctx).Info("my-message")`, then any datadog trace-information in the context will be added to the log-message's fields.

Note: This commit will fail until go-logger has released a new version, with the HookEntry-struct.

Closes https://github.com/coopnorge/go-logger/issues/61