### PR TITLE
feat(grpc): Add additional versions of grpc-interceptors, which are configurable

### DIFF
--- a/middleware/grpc/client.go
+++ b/middleware/grpc/client.go
@@ -7,6 +7,14 @@ import (
 )
 
 // TraceUnaryClientInterceptor create a client-interceptor to automatically create child-spans, and append to gRPC metadata.
+// Deprecated: Use UnaryClientInterceptor instead. This function will be removed in a later version.
 func TraceUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 	return ddGrpc.UnaryClientInterceptor()
+}
+
+// UnaryClientInterceptor create a client-interceptor to automatically create child-spans, and append to gRPC metadata.
+// UnaryServerInterceptor returns a middleware that creates datadog-spans on outgoing requests, and adds them to the request's gRPC-metadata.
+func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
+	opts := convertOptions(options...)
+	return ddGrpc.UnaryClientInterceptor(opts...)
 }

--- a/middleware/grpc/options.go
+++ b/middleware/grpc/options.go
@@ -1,0 +1,84 @@
+package grpc
+
+import (
+	"os"
+
+	"google.golang.org/grpc/codes"
+	ddGrpc "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+)
+
+// These options, unless otherwise specified, will be valid for both client and server interceptors.
+
+type config struct {
+	serviceName     string
+	nonErrorCodes   []codes.Code
+	untracedMethods []string
+	tags            map[string]any
+}
+
+func defaults() *config {
+	serviceName := os.Getenv("DD_SERVICE")
+	return &config{
+		serviceName:     serviceName,
+		nonErrorCodes:   []codes.Code{codes.Canceled},
+		untracedMethods: nil,
+		tags:            nil,
+	}
+}
+
+func convertOptions(options ...Option) []ddGrpc.Option {
+	cfg := defaults()
+	for _, opt := range options {
+		opt(cfg)
+	}
+	opts := make([]ddGrpc.Option, 0, 3+len(cfg.tags))
+	if cfg.serviceName != "" {
+		opts = append(opts, ddGrpc.WithServiceName(cfg.serviceName))
+	}
+	if len(cfg.nonErrorCodes) > 0 {
+		opts = append(opts, ddGrpc.NonErrorCodes(cfg.nonErrorCodes...))
+	}
+	if len(cfg.untracedMethods) > 0 {
+		opts = append(opts, ddGrpc.WithUntracedMethods(cfg.untracedMethods...))
+	}
+	for k, v := range cfg.tags {
+		opts = append(opts, ddGrpc.WithCustomTag(k, v))
+	}
+	return opts
+}
+
+// Option allows for overriding our default-config.
+type Option func(cfg *config)
+
+// WithServiceName overrides the service-name set in environment-variable "DD_SERVICE".
+func WithServiceName(serviceName string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = serviceName
+	}
+}
+
+// WithNonErrorCodes determines the list of codes which will not be considered errors in instrumentation.
+// This call overrides the default handling of codes.Canceled as a non-error.
+func WithNonErrorCodes(cs ...codes.Code) Option {
+	return func(cfg *config) {
+		cfg.nonErrorCodes = cs
+	}
+}
+
+// WithUntracedMethods specifies full methods to be ignored by the server side and client
+// side interceptors. When a request's full method is in 'methods', no spans will be created.
+func WithUntracedMethods(methods ...string) Option {
+	return func(cfg *config) {
+		cfg.untracedMethods = methods
+	}
+}
+
+// WithCustomTag will attach the value to the span tagged by the key.
+func WithCustomTag(key string, value any) Option {
+	return func(cfg *config) {
+		if cfg.tags == nil {
+			cfg.tags = make(map[string]any)
+		}
+		cfg.tags[key] = value
+	}
+}

--- a/middleware/grpc/server.go
+++ b/middleware/grpc/server.go
@@ -6,11 +6,25 @@ import (
 )
 
 // TraceUnaryServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
+// Deprecated: Use UnaryServerInterceptor instead. This function will be removed in a later version.
 func TraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return ddGrpc.UnaryServerInterceptor()
 }
 
 // TraceStreamServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
+// Deprecated: Use StreamServerInterceptor instead. This function will be removed in a later version.
 func TraceStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return ddGrpc.StreamServerInterceptor()
+}
+
+// UnaryServerInterceptor returns a middleware that creates datadog-spans on incoming requests, and stores them in the requests' context.
+func UnaryServerInterceptor(options ...Option) grpc.UnaryServerInterceptor {
+	opts := convertOptions(options...)
+	return ddGrpc.UnaryServerInterceptor(opts...)
+}
+
+// StreamServerInterceptor returns a middleware that creates datadog-spans on incoming requests, and stores them in the requests' context.
+func StreamServerInterceptor(options ...Option) grpc.StreamServerInterceptor {
+	opts := convertOptions(options...)
+	return ddGrpc.StreamServerInterceptor(opts...)
 }


### PR DESCRIPTION
Add options-pattern for configuring the grpc-server/client interceptors, and deprecate the old non-options interceptor.
