### PR TITLE
feat(http): Add additional version of http-wrapper, which is configurable

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,4 @@
 MD010:
   code_blocks: false
+MD013:
+  code_blocks: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Coop Datadog Go package
 
-![Test](https://github.com/coopnorge/go-datadog-lib/actions/workflows/test.yml/badge.svg)
-![Build](https://github.com/coopnorge/go-datadog-lib/actions/workflows/build.yml/badge.svg)
+![Build](https://github.com/coopnorge/go-datadog-lib/actions/workflows/cicd.yaml/badge.svg)
 
 Plug and play package that wraps base functionally and initialization of
 Datadog Service.
@@ -11,8 +10,12 @@ Datadog Service.
 
 Supported middleware to correlate/extend traceability and logs in Datadog.
 
-- [X] gRPC Unary Server
+- [X] gRPC Server
+- [X] gRPC Client
 - [X] HTTP - Echo
+- [X] HTTP - Standard library Client
+- [X] Database - GORM
+- [X] Database - Standard library
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Also provides abstract code to work with metrics.
 
 ## APM
 
-In Coop No our default setup is tracing applications with CPU profiling
+In Coop Norge, our default setup is tracing applications with CPU profiling
 support, that is enabled by default in the package bootstrap.
 
 ## Custom metrics - DD StatsD
@@ -140,7 +140,7 @@ func main() {
 }
 ```
 
-### 3. Middleware gRPC
+### 3. Middleware gRPC server
 
 To have better tracing you need add to your gRPC custom middleware that will
 extend context.
@@ -149,52 +149,37 @@ It's needed to relate logs with your trace data in APM.
 
 To do that, simply add Go - Datadog middleware to your gRPC interceptor.
 
-Take a look at the function `TraceUnaryServerInterceptor` in
-[`github.com/coopnorge/go-datadog-lib/blob/main/middleware/grpc/grpc.go`](https://github.com/coopnorge/go-datadog-lib/blob/main/middleware/grpc/grpc.go).
+Take a look at the function `UnaryServerInterceptor` in
+[`github.com/coopnorge/go-datadog-lib/blob/main/middleware/grpc/server.go`](https://github.com/coopnorge/go-datadog-lib/blob/main/middleware/grpc/server.go).
 
 ```go
 import (
+	coopdatadog "github.com/coopnorge/go-datadog-lib/v2"
 	datadogMiddleware "github.com/coopnorge/go-datadog-lib/v2/middleware/grpc"
 	"google.golang.org/grpc"
 )
 
 func main() {
+	err := coopdatadog.StartDatadog(...)
+	if err != nil {
+		panic(err)
+	}
+	defer coopdatadog.GracefulDatadogShutdown()
+
+
+	ddOpts := []datadogMiddleware.Option{
+		// ...
+	}
 	serverOpts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(datadogMiddleware.TraceUnaryServerInterceptor()),
+		grpc.UnaryInterceptor(datadogMiddleware.UnaryServerInterceptor(ddOpts...)),
+		grpc.StreamInterceptor(datadogMiddleware.StreamServerInterceptor(ddOpts...))
 	}
 
 	grpcServer := grpc.NewServer(serverOpts...)
 }
 ```
 
-#### Using `cfgBuilder`
-
-```go
-package myServer
-
-import (
-	"github.com/coopnorge/go-datadog-lib/v2/middleware/grpc"
-	"github.com/labstack/echo/v4"
-)
-
-func MyServer() {
-	// ...
-  
-	// This is gRPC server configuration builder
-	cfgBuilder.AddGrpcUnaryInterceptors(
-		grpctrace.UnaryServerInterceptor(
-			grpctrace.WithServiceName(cfg.DatadogService),
-			grpctrace.WithStreamCalls(false),
-		),
-		grpc.TraceUnaryServerInterceptor(),
-	)
-
-	// This middleware will extend context for tracing and logs
-	// grpc.TraceUnaryServerInterceptor()
-}
-```
-
-### 3. Middleware echo
+### 3. Middleware echo server
 
 Same as gRPC middleware but for Echo framework. It will extend request context
 and will allow to create nested spans for it, also correlate with logs.
@@ -210,6 +195,12 @@ import (
 )
 
 func MyServer() {
+	err := coopdatadog.StartDatadog(...)
+	if err != nil {
+		panic(err)
+	}
+	defer coopdatadog.GracefulDatadogShutdown()
+
 	// ...
 	echoServer := echo.New()
 	// Some other configuration
@@ -219,7 +210,7 @@ func MyServer() {
 }
 ```
 
-### Common issue
+#### Common issue
 
 After that Datadog will try to connect to the socket and will start to send all
 information in the background.
@@ -228,6 +219,161 @@ In different setup, you could have error logs that Datadog cannot connect to
 the socket and tried to connect via HTTP. That could be related to issue when
 your container starts faster and sockets were not ready to communicate with
 Agent or Agent was started later.
+
+### 4. Middleware gRPC client
+
+If your application is making outgoing gRPC calls, you can add the gRPC
+client-interceptor to automatically create child-spans for each outgoing gRPC-call.
+These spans will also be embedded in the outgoing gRPC-metadata, so if you are calling
+another service that is also instrumented with DataDog-integration, then you will
+enable distributed tracing.
+
+It is important that the context used in the RPC contains trace-information,
+preferably created from any server middleware from this module.
+
+Example:
+
+```go
+import (
+	datadogMiddleware "github.com/coopnorge/go-datadog-lib/v2/middleware/grpc"
+	"google.golang.org/grpc"
+	myprotov1 "some/import/path"
+)
+
+func foo() {
+	cc, err := grpc.Dial(
+		url,
+		grpc.WithUnaryInterceptor(ddGrpc.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	client := myprotov1.NewFoobarAPIClient(cc)
+
+	_, err := client.SomeUnaryRPC(ctx, myprotov1.SomeUnaryRPCRequest{})
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+### 4. Middleware HTTP client
+
+If your application is making outgoing HTTP calls, you can add the HTTP
+client-interceptor to automatically create child-spans for each outgoing HTTP-call.
+These spans will also be embedded in the outgoing HTTP Headers, so if you are calling
+another service that is also instrumented with DataDog-integration, then you will
+enable distributed tracing.
+
+It is important that the context used in the http.Request contains trace-information,
+preferably created from any server middleware from this module.
+
+Example:
+
+```go
+import (
+	datadogMiddleware "github.com/coopnorge/go-datadog-lib/v2/middleware/grpc"
+	"google.golang.org/grpc"
+)
+
+func foo() {
+	client := &http.Client{
+		Timeout: 10*time.Second,
+	}
+	client = datadogMiddleware.AddTracingToClient(client)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+### 4. Middleware database standard library
+
+If your application is making outgoing call to a database, you can add the database
+driver to automatically create child-spans for each outgoing database-call.
+
+It is important that the context used in the call to the database contains trace-information,
+preferably created from any server middleware from this module.
+
+Example:
+
+```go
+import (
+	ddDatabase "github.com/coopnorge/go-datadog-lib/v2/middleware/database"
+	mysqlDriver "github.com/go-sql-driver/mysql"
+)
+
+func foo() {
+	// Example using mysql driver
+	db, err := ddDatabase.RegisterDriverAndOpen("mysql", mysqlDriver.MySQLDriver{}, dsn, opts...)
+	if err != nil{
+		panic(err)
+	}
+
+	_, err := db.QueryContext(ctx, "SELECT * FROM users")
+}
+```
+
+### 4. Middleware database GORM
+
+If your application is using GORM to make outgoing calls to a database, you can
+add the GORM middleware to automatically create child-spans for each outgoing database-call.
+
+It is important that the context used in the call to the database contains trace-information,
+preferably created from any server middleware from this module.
+
+Example:
+
+```go
+import (
+	ddGorm "github.com/coopnorge/go-datadog-lib/v2/middleware/gorm"
+	mysqlDriver "github.com/go-sql-driver/mysql"
+)
+
+func foo() {
+	// Example using mysql driver
+	gormDB, err := ddGorm.NewORM(mysql.New(mysql.Config{Conn: sqlDb}), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	user := &entity.User{}
+	_ := gormDB.WithContext(ctx).Select("*").First(user)
+}
+```
+
+You can also combine this with the standard library tracer-middleware:
+
+```go
+import (
+	ddDatabase "github.com/coopnorge/go-datadog-lib/v2/middleware/database"
+	mysqlDriver "github.com/go-sql-driver/mysql"
+)
+
+func foo() {
+	// Example using mysql driver
+	db, err := ddDatabase.RegisterDriverAndOpen("mysql", mysqlDriver.MySQLDriver{}, dsn, opts...)
+	if err != nil{
+		panic(err)
+	}
+
+	gormDB, err := ddGorm.NewORM(mysql.New(mysql.Config{Conn: db}), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	user := &entity.User{}
+	_ := gormDB.WithContext(ctx).Select("*").First(user)
+}
+```
 
 ## Metric - Datadog StatsD
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -225,7 +225,7 @@ Agent or Agent was started later.
 If your application is making outgoing gRPC calls, you can add the gRPC
 client-interceptor to automatically create child-spans for each outgoing gRPC-call.
 These spans will also be embedded in the outgoing gRPC-metadata, so if you are calling
-another service that is also instrumented with DataDog-integration, then you will
+another service that is also instrumented with Datadog-integration, then you will
 enable distributed tracing.
 
 It is important that the context used in the RPC contains trace-information,
@@ -263,7 +263,7 @@ func foo() {
 If your application is making outgoing HTTP calls, you can add the HTTP
 client-interceptor to automatically create child-spans for each outgoing HTTP-call.
 These spans will also be embedded in the outgoing HTTP Headers, so if you are calling
-another service that is also instrumented with DataDog-integration, then you will
+another service that is also instrumented with Datadog-integration, then you will
 enable distributed tracing.
 
 It is important that the context used in the http.Request contains trace-information,

--- a/middleware/http/client.go
+++ b/middleware/http/client.go
@@ -8,9 +8,17 @@ import (
 )
 
 // WrapClient wraps the net/http.Client to automatically create child-spans, and append to HTTP Headers.
+// Deprecated: Use AddTracingToClient instead, and set a proper ResourceNamer. This function will be removed in a later version.
 func WrapClient(client *http.Client) *http.Client {
-	if internal.IsDatadogConfigured() {
-		client = httptrace.WrapClient(client)
+	// Note: Explicitly setting ResourceNamer to `nil`, to prevent leaking paths and keeping backwards-compatibility.
+	return AddTracingToClient(client, WithResourceNamer(nil))
+}
+
+// AddTracingToClient wraps the net/http.Client to automatically create child-spans, and append to HTTP Headers.
+func AddTracingToClient(client *http.Client, options ...Option) *http.Client {
+	if !internal.IsDatadogConfigured() {
+		return client
 	}
-	return client
+	opts := convertClientOptions(options...)
+	return httptrace.WrapClient(client, opts...)
 }

--- a/middleware/http/options.go
+++ b/middleware/http/options.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"net/http"
+	"os"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// These options, unless otherwise specified, will be valid for both client and server interceptors.
+
+// ResourceNamer is a function that  will be called to determine what the ResourceName of the span should be.
+type ResourceNamer func(req *http.Request) string
+
+// RequestIgnorer is a function that  will be called to determine if the request should be traced or not.
+type RequestIgnorer func(req *http.Request) bool
+
+type config struct {
+	serviceName    string
+	resourceNamer  ResourceNamer
+	requestIgnorer RequestIgnorer
+	tags           map[string]any
+}
+
+func defaults() *config {
+	serviceName := os.Getenv("DD_SERVICE")
+	return &config{
+		serviceName:    serviceName,
+		resourceNamer:  FullURLResourceNamer(),
+		requestIgnorer: nil,
+		tags:           nil,
+	}
+}
+
+// convertClientOptions converts the Options to httptrace-typed options.
+// httptrace-clients use httptrace.RoundTripperOption.
+// httptrace-servers use httptrace.Option.
+func convertClientOptions(options ...Option) []httptrace.RoundTripperOption {
+	cfg := defaults()
+	for _, opt := range options {
+		opt(cfg)
+	}
+	opts := make([]httptrace.RoundTripperOption, 0, 3+len(cfg.tags))
+	if cfg.serviceName != "" {
+		opts = append(opts, httptrace.RTWithServiceName(cfg.serviceName))
+	}
+	if cfg.resourceNamer != nil {
+		opts = append(opts, httptrace.RTWithResourceNamer(cfg.resourceNamer))
+	}
+	if cfg.requestIgnorer != nil {
+		opts = append(opts, httptrace.RTWithIgnoreRequest(cfg.requestIgnorer))
+	}
+	for k, v := range cfg.tags {
+		opts = append(opts, httptrace.RTWithSpanOptions(tracer.Tag(k, v)))
+	}
+	return opts
+}
+
+// Option allows for overriding our default-config.
+type Option func(cfg *config)
+
+// WithServiceName overrides the service-name set in environment-variable "DD_SERVICE".
+func WithServiceName(serviceName string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = serviceName
+	}
+}
+
+// WithResourceNamer specifies a function that will be called to determine what
+// the ResourceName of the span should be.
+// For example, in the span "http.client https://coop.no/", the ResourceName is "https://coop.no/"
+func WithResourceNamer(resourceNamer ResourceNamer) Option {
+	return func(cfg *config) {
+		cfg.resourceNamer = resourceNamer
+	}
+}
+
+// WithRequestIgnorer specifies a function that will be called to determined if
+// the request should be traced or not.
+func WithRequestIgnorer(requestIgnorer RequestIgnorer) Option {
+	return func(cfg *config) {
+		cfg.requestIgnorer = requestIgnorer
+	}
+}
+
+// WithCustomTag will attach the value to the span tagged by the key.
+func WithCustomTag(key string, value any) Option {
+	return func(cfg *config) {
+		if cfg.tags == nil {
+			cfg.tags = make(map[string]any)
+		}
+		cfg.tags[key] = value
+	}
+}
+
+// StaticResourceNamer will set every span's ResourceName to str.
+func StaticResourceNamer(str string) ResourceNamer {
+	return func(req *http.Request) string {
+		return str
+	}
+}
+
+// FullURLWithParamsResourceNamer will name the ResourceName to "GET https://www.coop.no/api/some-service/some-endpoint?foo=bar"
+// NOTE! This might leak unintended user-ids, credentials, or other things that are part of a URL.
+func FullURLWithParamsResourceNamer() ResourceNamer {
+	return func(req *http.Request) string {
+		return req.Method + " " + req.URL.Redacted()
+	}
+}
+
+// FullURLResourceNamer will name the ResourceName to "GET https://www.coop.no/api/some-service/some-endpoint"
+// NOTE! This might leak unintended user-ids, if they are part of the URL-path.
+func FullURLResourceNamer() ResourceNamer {
+	return func(req *http.Request) string {
+		u := req.URL
+		return req.Method + " " + u.Scheme + "://" + u.Host + u.Path
+	}
+}
+
+// HostResourceNamer will name the ResourceName to "www.coop.no"
+func HostResourceNamer() ResourceNamer {
+	return func(req *http.Request) string {
+		return req.URL.Host
+	}
+}

--- a/middleware/http/options_test.go
+++ b/middleware/http/options_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHostResourceNamer(t *testing.T) {
-	rn := HostResourceNamer()
-	req, err := http.NewRequest("GET", "https://www.coop.no/api/some-service/some-endpoint", nil)
-	require.NoError(t, err)
-	require.Equal(t, "www.coop.no", rn(req))
-
-	q := req.URL.Query()
-	q.Add("foo", "bar")
-	req.URL.RawQuery = q.Encode()
-	require.Equal(t, "www.coop.no", rn(req))
-
-	req.SetBasicAuth("bax", "baz")
-	req.URL.User = url.UserPassword("bax", "baz")
-	require.Equal(t, "www.coop.no", rn(req))
-}
-
 func TestResourceNamers(t *testing.T) {
 	testCases := []struct {
 		name                         string

--- a/middleware/http/options_test.go
+++ b/middleware/http/options_test.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostResourceNamer(t *testing.T) {
+	rn := HostResourceNamer()
+	req, err := http.NewRequest("GET", "https://www.coop.no/api/some-service/some-endpoint", nil)
+	require.NoError(t, err)
+	require.Equal(t, "www.coop.no", rn(req))
+
+	q := req.URL.Query()
+	q.Add("foo", "bar")
+	req.URL.RawQuery = q.Encode()
+	require.Equal(t, "www.coop.no", rn(req))
+
+	req.SetBasicAuth("bax", "baz")
+	req.URL.User = url.UserPassword("bax", "baz")
+	require.Equal(t, "www.coop.no", rn(req))
+}
+
+func TestResourceNamers(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		rn                           ResourceNamer
+		expectedFullPath             string
+		expectedFullWithQuery        string
+		expectedFullWithQueryAndUser string
+	}{
+		{
+			name:                         "StaticResourceNamer",
+			rn:                           StaticResourceNamer("foobar"),
+			expectedFullPath:             "foobar",
+			expectedFullWithQuery:        "foobar",
+			expectedFullWithQueryAndUser: "foobar",
+		},
+		{
+			name:                         "FullURLWithParamsResourceNamer",
+			rn:                           FullURLWithParamsResourceNamer(),
+			expectedFullPath:             "GET https://www.coop.no/api/some-service/some-endpoint",
+			expectedFullWithQuery:        "GET https://www.coop.no/api/some-service/some-endpoint?foo=bar",
+			expectedFullWithQueryAndUser: "GET https://bax:xxxxx@www.coop.no/api/some-service/some-endpoint?foo=bar",
+		},
+		{
+			name:                         "FullURLResourceNamer",
+			rn:                           FullURLResourceNamer(),
+			expectedFullPath:             "GET https://www.coop.no/api/some-service/some-endpoint",
+			expectedFullWithQuery:        "GET https://www.coop.no/api/some-service/some-endpoint",
+			expectedFullWithQueryAndUser: "GET https://www.coop.no/api/some-service/some-endpoint",
+		},
+		{
+			name:                         "HostResourceNamer",
+			rn:                           HostResourceNamer(),
+			expectedFullPath:             "www.coop.no",
+			expectedFullWithQuery:        "www.coop.no",
+			expectedFullWithQueryAndUser: "www.coop.no",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest("GET", "https://www.coop.no/api/some-service/some-endpoint", nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedFullPath, tc.rn(req))
+
+			q := req.URL.Query()
+			q.Add("foo", "bar")
+			req.URL.RawQuery = q.Encode()
+			require.Equal(t, tc.expectedFullWithQuery, tc.rn(req))
+
+			req.SetBasicAuth("bax", "baz")
+			req.URL.User = url.UserPassword("bax", "baz")
+			require.Equal(t, tc.expectedFullWithQueryAndUser, tc.rn(req))
+		})
+	}
+}


### PR DESCRIPTION
Note: when migrating from `WrapClient` to `AddTracingToClient`, you should look into which ResourceNamer is suitable for the calls you make.

The default is set to `FullURLResourceNamer`, which will produce ResourceNames like `GET https://www.coop.no/api/some-service/some-endpoint`.

If you are making calls to e.g. `https://www.coop.no/api/customer/123`, then you probably want to create a custom ResourceNamer that does not include `123`.

Closes #243