### PR TITLE
fix: Deprecated comments

### DIFF
--- a/middleware/grpc/client.go
+++ b/middleware/grpc/client.go
@@ -7,6 +7,7 @@ import (
 )
 
 // TraceUnaryClientInterceptor create a client-interceptor to automatically create child-spans, and append to gRPC metadata.
+//
 // Deprecated: Use UnaryClientInterceptor instead. This function will be removed in a later version.
 func TraceUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 	return ddGrpc.UnaryClientInterceptor()

--- a/middleware/grpc/server.go
+++ b/middleware/grpc/server.go
@@ -6,12 +6,14 @@ import (
 )
 
 // TraceUnaryServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
+//
 // Deprecated: Use UnaryServerInterceptor instead. This function will be removed in a later version.
 func TraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return ddGrpc.UnaryServerInterceptor()
 }
 
 // TraceStreamServerInterceptor for Datadog Log Integration, middleware will create span that can be used from context
+//
 // Deprecated: Use StreamServerInterceptor instead. This function will be removed in a later version.
 func TraceStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return ddGrpc.StreamServerInterceptor()

--- a/middleware/http/client.go
+++ b/middleware/http/client.go
@@ -8,6 +8,7 @@ import (
 )
 
 // WrapClient wraps the net/http.Client to automatically create child-spans, and append to HTTP Headers.
+//
 // Deprecated: Use AddTracingToClient instead, and set a proper ResourceNamer. This function will be removed in a later version.
 func WrapClient(client *http.Client) *http.Client {
 	// Note: Explicitly setting ResourceNamer to `nil`, to prevent leaking paths and keeping backwards-compatibility.

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -30,6 +30,7 @@ func CreateNestedTrace(sourceCtx context.Context, operation, resource string) (d
 }
 
 // AppendUserToTrace includes identifier of user that would be attached to span in datadog
+//
 // Deprecated: AppendUserToTrace previously added CoopID to Datadog-spans, which could be used to look up other PII-information. This is not wanted, and has been replaced with a no-op.
 func AppendUserToTrace(_ context.Context, _ string) error {
 	return nil


### PR DESCRIPTION
Deprecated comments must be preceded by a blank line or blank comment line or
it will not be detected by golangci-lint. See external example
<https://go.dev/wiki/Deprecated>.
