### PR TITLE
deprecate trace logging v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.4.0
-	github.com/coopnorge/go-logger v0.6.0
+	github.com/coopnorge/go-logger v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/labstack/echo/v4 v4.11.4

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coopnorge/go-logger v0.6.0 h1:xIdBu1ITOwVy1NiJMhWgZLbO5GGJCWMfbd9a7jwZI2A=
-github.com/coopnorge/go-logger v0.6.0/go.mod h1:1TOC146ZNCxtputAVHTCEFir37tuNZgqIZv5u8JnLmE=
+github.com/coopnorge/go-logger v0.7.0 h1:teWJ3CR12GCsZfEEY/CBS9xi4jDSw5cPXOLeKjz9KzU=
+github.com/coopnorge/go-logger v0.7.0/go.mod h1:1TOC146ZNCxtputAVHTCEFir37tuNZgqIZv5u8JnLmE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coopnorge/go-datadog-lib/v2/tracing"
 	"github.com/coopnorge/go-logger"
 
 	"github.com/iancoleman/strcase"
@@ -76,10 +75,6 @@ func (m BaseMetricCollector) AddMetric(ctx context.Context, d Data) {
 	}
 
 	if metricCollectionErr != nil {
-		tracing.LogWithTrace(
-			ctx,
-			logger.LevelError,
-			fmt.Sprintf("Failed to collect metrics metricData for Name=%s - error: %v", metricName, metricCollectionErr),
-		)
+		logger.WithContext(ctx).WithError(metricCollectionErr).Errorf("Failed to collect metrics metricData for Name=%s", metricName)
 	}
 }

--- a/tracing/log.go
+++ b/tracing/log.go
@@ -2,10 +2,8 @@ package tracing
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coopnorge/go-logger"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // LogWithTrace will log message by logger.Level with trace if it's present in context.Context
@@ -14,10 +12,8 @@ import (
 // should not be used. Use logger.WithContext(ctx Context) from
 // github.com/coopnorge/go-logger
 func LogWithTrace(sourceCtx context.Context, severity logger.Level, message string) {
-	messageToLog := getMessageToLog(sourceCtx, message)
-	emptyEntry := logger.WithFields(map[string]interface{}{})
-
-	logWithSeverity(emptyEntry, severity, messageToLog)
+	entry := logger.WithContext(sourceCtx)
+	logWithSeverity(entry, severity, message)
 }
 
 // LogFieldsWithTrace will log message by logger.Level with trace if it's present in context.Context
@@ -26,36 +22,21 @@ func LogWithTrace(sourceCtx context.Context, severity logger.Level, message stri
 // should not be used. Use logger.WithContext(ctx Context) from
 // github.com/coopnorge/go-logger
 func LogFieldsWithTrace(sourceCtx context.Context, severity logger.Level, message string, fields logger.Fields) {
-	messageToLog := getMessageToLog(sourceCtx, message)
-	entry := logger.WithFields(fields)
-
-	logWithSeverity(entry, severity, messageToLog)
+	entry := logger.WithContext(sourceCtx).WithFields(fields)
+	logWithSeverity(entry, severity, message)
 }
 
-func getMessageToLog(ctx context.Context, message string) string {
-	var messageToLog string
-
-	span, exists := tracer.SpanFromContext(ctx)
-	if exists {
-		messageToLog = fmt.Sprintf("%s %v dd.lang=go", message, span)
-	} else {
-		messageToLog = message
-	}
-
-	return messageToLog
-}
-
-func logWithSeverity(entry logger.Entry, severity logger.Level, message string) {
+func logWithSeverity(entry *logger.Entry, severity logger.Level, message string) {
 	switch severity {
 	case logger.LevelFatal:
-		entry.Fatalf(message)
+		entry.Fatal(message)
 	case logger.LevelError:
-		entry.Errorf(message)
+		entry.Error(message)
 	case logger.LevelWarn:
-		entry.Warnf(message)
+		entry.Warn(message)
 	case logger.LevelInfo:
-		entry.Infof(message)
+		entry.Info(message)
 	case logger.LevelDebug:
-		entry.Debugf(message)
+		entry.Debug(message)
 	}
 }

--- a/tracing/log.go
+++ b/tracing/log.go
@@ -9,6 +9,10 @@ import (
 )
 
 // LogWithTrace will log message by logger.Level with trace if it's present in context.Context
+//
+// Deprecated: LogWithTrace will be removed in a future major version and
+// should not be used. Use logger.WithContext(ctx Context) from
+// github.com/coopnorge/go-logger
 func LogWithTrace(sourceCtx context.Context, severity logger.Level, message string) {
 	messageToLog := getMessageToLog(sourceCtx, message)
 	emptyEntry := logger.WithFields(map[string]interface{}{})
@@ -17,6 +21,10 @@ func LogWithTrace(sourceCtx context.Context, severity logger.Level, message stri
 }
 
 // LogFieldsWithTrace will log message by logger.Level with trace if it's present in context.Context
+//
+// Deprecated: LogFieldsWithTrace will be removed in a future major version and
+// should not be used. Use logger.WithContext(ctx Context) from
+// github.com/coopnorge/go-logger
 func LogFieldsWithTrace(sourceCtx context.Context, severity logger.Level, message string, fields logger.Fields) {
 	messageToLog := getMessageToLog(sourceCtx, message)
 	entry := logger.WithFields(fields)


### PR DESCRIPTION
- chore: Deprecate funtions replaced by logger.WithContext
- chore: Deprecate functions and replace them with logger.WithContext
