### PR TITLE
feat: Add `config.Validate()`

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -22,8 +22,8 @@ const (
 // StartDatadog parallel process to collect data for Datadog.
 // connectionType flag related to Datadog connection type, it supports HTTP or socket - values will be used from config.DatadogParameters
 func StartDatadog(cfg config.DatadogParameters, connectionType ConnectionType) error {
-	if !cfg.IsDataDogConfigValid() {
-		return fmt.Errorf("datadog configuration not valid, cannot initialize Datadog services")
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("Datadog configuration not valid, cannot initialize Datadog services: %w", err)
 	}
 
 	initTracer(cfg, connectionType)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,37 @@ func TestIsDataDogConfigValid(t *testing.T) {
 	assert.True(t, cfg.IsDataDogConfigValid())
 }
 
+func TestValidate(t *testing.T) {
+	cfg := DatadogConfig{}
+
+	assert.Error(t, cfg.Validate())
+
+	cfg.Env = "dev"
+	assert.Error(t, cfg.Validate())
+
+	cfg.Service = "Lib"
+	assert.Error(t, cfg.Validate())
+
+	cfg.ServiceVersion = "v1"
+	assert.Error(t, cfg.Validate())
+
+	cfg.APM = ""
+	cfg.DSD = ""
+	assert.Error(t, cfg.Validate())
+
+	cfg.APM = ""
+	cfg.DSD = "unix///tmp"
+	assert.Nil(t, cfg.Validate())
+
+	cfg.APM = "unix///tmp"
+	cfg.DSD = ""
+	assert.Nil(t, cfg.Validate())
+
+	cfg.DSD = "unix///tmp"
+	cfg.APM = "unix///tmp"
+	assert.Nil(t, cfg.Validate())
+}
+
 func TestConfigGetters(t *testing.T) {
 	expectedCfg := DatadogConfig{
 		Env:            "unit",


### PR DESCRIPTION
`config.IsDataDogConfigValid()` does not tell us what is wrong with the
configuration leaving the user to guess or inspect the code and configuration.

In stead we should raise errors telling the user what is wrong.

Resolves: https://github.com/coopnorge/go-datadog-lib/issues/281
