### PR TITLE
fix: gormtrace panics when nil config is provided

### DIFF
--- a/middleware/gorm/gorm.go
+++ b/middleware/gorm/gorm.go
@@ -26,6 +26,11 @@ func NewORM(dialector gorm.Dialector, gormCfg *gorm.Config, options ...Option) (
 		opts = append(opts, gormtrace.WithCustomTag(k, staticTagger))
 	}
 
+	if gormCfg == nil {
+		// gormtrace panics if gormCfg is nil
+		// create a new one if it's not provided
+		gormCfg = &gorm.Config{}
+	}
 	return gormtrace.Open(dialector, gormCfg, opts...)
 }
 


### PR DESCRIPTION
`gormtrace.Open` call `gorm.Open` which accepts vardic options arguments.
And if config passed is nil, `gorm.Open` accepts at is a valid `Option`
and tries to call `Apply` on it an panic.

There isn't much we can do about it except for passing in a new
`Config` when gormCfg is nil.
