### PR TITLE
chore: Reduce the number of users requested to review updates

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -14,7 +14,8 @@ approval_rules:
     invalidate_on_push: true
     request_review:
       enabled: true
-      mode: all-users
+      mode: random-users
+      count: 8
     methods:
       github_review: true
   if:


### PR DESCRIPTION
In order to reduce the notification storm that hits users when dependencies are
update select a set of random users from engineering to review rather than the
whole team.

Ref:
- https://github.com/coopnorge/go-datadog-lib/pull/324
