### PR TITLE
chore: Use mage for CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,6 +6,14 @@ on:
       - main
 
 jobs:
+  mage:
+    uses: coopnorge/mage/.github/workflows/mage.yaml@v0
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    secrets: inherit
+
   golang-ci:
     name: Go Lang CI
     runs-on: ubuntu-latest
@@ -54,6 +62,7 @@ jobs:
 
   build:
     needs:
+      - mage
       - golang-ci
       - techdocs
     if: always()
@@ -62,6 +71,8 @@ jobs:
       - run: exit 1
         name: "Catch errors"
         if: |
+          needs.mage.result == 'failure' ||
           needs.golang-ci.result == 'failure' ||
           needs.techdocs.result == 'failure'
     permissions: {}
+

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ docker compose run --rm golang-devtools gomockhandler -config ./gomockhandler.js
 
 ### Validate
 
-```bash
-docker compose run --rm golang-devtools validate
+```console
+go tool mage validate
 ```
 
 ### Other targets
 
-```bash
-docker compose run --rm golang-devtools help
+```console
+go tool mage -l
 ```
 
 ## User documentation

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -45,7 +45,7 @@ func Start(ctx context.Context, opts ...Option) (StopFunc, error) {
 
 	l, err := datadogLogger.NewLogger(datadogLogger.WithGlobalLogger())
 	if err != nil {
-		return noop, fmt.Errorf("Failed to initialize the Datadog logger: %w", err)
+		return noop, fmt.Errorf("failed to initialize the Datadog logger: %w", err)
 	}
 	ddtrace.UseLogger(l)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/coopnorge/go-logger v0.11.5
+	github.com/coopnorge/mage v0.4.2
 	github.com/go-sql-driver/mysql v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/iancoleman/strcase v0.3.0
@@ -56,6 +57,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c // indirect
+	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
@@ -105,3 +107,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool github.com/magefile/mage

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/coopnorge/go-logger v0.11.5 h1:Pxku1DzdSNIXiseZslKl6nAM7rC86z/FNdWIpRtUoTo=
 github.com/coopnorge/go-logger v0.11.5/go.mod h1:/isA+OwX902HYrvDbRA0VZ8bfvxztEr0r1Wc2zlkkZM=
+github.com/coopnorge/mage v0.4.2 h1:F8zmXYwoQCKEvc8a747aDqZcY9XgHjH5Kjw2KAu47c0=
+github.com/coopnorge/mage v0.4.2/go.mod h1:IG2EaeUXpTBwvEHL5lUeHjcxljMRQeVC6y4tQm/X1TU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -137,6 +139,8 @@ github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c h1:VtwQ41oftZwlMnOEbMWQtSEUgU64U4s+GHk7hZK+jtY=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
+github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
+github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/legacy_bootstrap.go
+++ b/legacy_bootstrap.go
@@ -44,12 +44,12 @@ func StartDatadog(cfg config.DatadogParameters, connectionType ConnectionType) e
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("Datadog configuration not valid, cannot initialize Datadog services: %w", err)
+		return fmt.Errorf("the Datadog configuration not valid, cannot initialize Datadog services: %w", err)
 	}
 
 	l, err := datadogLogger.NewLogger(datadogLogger.WithGlobalLogger())
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the Datadog logger: %w", err)
+		return fmt.Errorf("failed to initialize the Datadog logger: %w", err)
 	}
 	ddtrace.UseLogger(l)
 
@@ -61,7 +61,7 @@ func StartDatadog(cfg config.DatadogParameters, connectionType ConnectionType) e
 
 	initTracer(cfg, connectionType)
 	if initProfilerErr := initProfiler(cfg, connectionType); initProfilerErr != nil {
-		return fmt.Errorf("Failed to start Datadog profiler: %w", initProfilerErr)
+		return fmt.Errorf("failed to start Datadog profiler: %w", initProfilerErr)
 	}
 
 	return nil

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	//mage:import
+	_ "github.com/coopnorge/mage/targets/golib"
+)


### PR DESCRIPTION
This change enables CI using mage. The linting configuration found some casing
issues in a few errors messages that have been fixed at the same time.

Removing the old devtools will be done as a separate change.