### PR TITLE
fix: Go directive should use the full version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-datadog-lib/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
Ref: https://inventory.internal.coop/docs/default/component/guidelines/languages/go/#the-gomod-file
