### PR TITLE
fix: Properly initialize the testpb.InterceptorTestSuite

### DIFF
--- a/middleware/grpc/server_test.go
+++ b/middleware/grpc/server_test.go
@@ -62,14 +62,12 @@ func (s *testPingService) PingList(_ *testpb.PingListRequest, stream testpb.Test
 
 func TestTraceStreamServerInterceptor(t *testing.T) {
 	s := &streamServerInterceptorTestSuite{
-		&testpb.InterceptorTestSuite{
-			TestService: &testPingService{
-				t: t,
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testPingService{&testpb.TestPingService{}, t},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(TraceStreamServerInterceptor()),
 			},
 		},
-	}
-	s.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
-		grpc.StreamInterceptor(TraceStreamServerInterceptor()),
 	}
 	suite.Run(t, s)
 }


### PR DESCRIPTION
Use the same pattern as in
https://github.com/grpc-ecosystem/go-grpc-middleware/blob/66bb7d8818ff22b450b82111a1260ca6dfe3486c/interceptors/auth/auth_test.go#L72-L84
to initialize the test suite.

This should resolve the errors in
https://github.com/coopnorge/go-datadog-lib/pull/444 in the check run https://github.com/coopnorge/go-datadog-lib/actions/runs/12360772766/job/34496457243?pr=444#step:10:173
