### PR TITLE
docs: Remove DD_AGENT_HOST info

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,6 @@ resource as well.
 
 Environmental variables:
 
-- `DD_AGENT_HOST`
 - `DD_DOGSTATSD_URL`
 - `DD_TRACE_AGENT_URL`
 - `DD_SERVICE`
@@ -80,10 +79,6 @@ spec:
       serviceAccountName: my-app
       containers:
           env:
-            - name: DD_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DD_DOGSTATSD_URL
               value: "unix:///var/run/datadog/dsd.socket"
             - name: DD_TRACE_AGENT_URL

--- a/internal/env.go
+++ b/internal/env.go
@@ -21,9 +21,6 @@ const (
 	DatadogDSDEndpoint = "DD_DOGSTATSD_URL"
 	// DatadogAPMEndpoint is the environment variable key for the URL to APM.
 	DatadogAPMEndpoint = "DD_TRACE_AGENT_URL"
-	// DatadogAgentHost is the environment variable key for the host name to
-	// connect to Datadog.
-	DatadogAgentHost = "DD_AGENT_HOST"
 )
 
 // IsDatadogDisabled checks if the Datadog integration is disabled. The


### PR DESCRIPTION
`DD_AGENT_HOST` is currently not required, the docs should reflect this.
