### PR TITLE
refactor: Simplify metric-options

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -62,7 +62,7 @@ func Gauge(name string, value float64, options ...Option) {
 	}
 	err = statsdClient.Gauge(name, value, localOpts.tags, localOpts.sampleRate)
 	if err != nil {
-		globalOpts.errorHandler(fmt.Errorf("failed to send Gauge: %w", err))
+		localOpts.errorHandler(fmt.Errorf("failed to send Gauge: %w", err))
 	}
 }
 
@@ -76,7 +76,7 @@ func Count(name string, value int64, options ...Option) {
 	}
 	err = statsdClient.Count(name, value, localOpts.tags, localOpts.sampleRate)
 	if err != nil {
-		globalOpts.errorHandler(fmt.Errorf("failed to to send Count: %w", err))
+		localOpts.errorHandler(fmt.Errorf("failed to to send Count: %w", err))
 	}
 }
 
@@ -104,7 +104,7 @@ func Distribution(name string, value float64, options ...Option) {
 	}
 	err = statsdClient.Distribution(name, value, localOpts.tags, localOpts.sampleRate)
 	if err != nil {
-		globalOpts.errorHandler(fmt.Errorf("failed to to send Distribution: %w", err))
+		localOpts.errorHandler(fmt.Errorf("failed to to send Distribution: %w", err))
 	}
 }
 
@@ -128,7 +128,7 @@ func Set(name string, value string, options ...Option) {
 	}
 	err = statsdClient.Set(name, value, localOpts.tags, localOpts.sampleRate)
 	if err != nil {
-		globalOpts.errorHandler(fmt.Errorf("failed to to send Set: %w", err))
+		localOpts.errorHandler(fmt.Errorf("failed to to send Set: %w", err))
 	}
 }
 
@@ -147,7 +147,7 @@ func TimeInMilliseconds(name string, value float64, options ...Option) {
 	}
 	err = statsdClient.TimeInMilliseconds(name, value, localOpts.tags, localOpts.sampleRate)
 	if err != nil {
-		globalOpts.errorHandler(fmt.Errorf("failed to to send TimeInMilliseconds: %w", err))
+		localOpts.errorHandler(fmt.Errorf("failed to to send TimeInMilliseconds: %w", err))
 	}
 }
 

--- a/metrics/metrics_internal_test.go
+++ b/metrics/metrics_internal_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This test verifies that we can set a global error-handler, but then override it on a per-metric basis.
+func TestOverrideGlobalValues(t *testing.T) {
+	oldGlobalOpts := globalOpts
+	t.Cleanup(func() { globalOpts = oldGlobalOpts })
+
+	optionThatCausesError := Option(func(*options) error { return fmt.Errorf("always return error") })
+
+	globalCount := 0
+	globalErrHandler := func(_ error) { globalCount++ }
+
+	localCount := 0
+	localErrHandler := func(_ error) { localCount++ }
+
+	globalOpts = &options{errorHandler: globalErrHandler, sampleRate: 1.0}
+
+	Gauge("some_metric", 1.0, optionThatCausesError)
+	assert.Equal(t, 1, globalCount)
+	assert.Equal(t, 0, localCount)
+
+	Gauge("some_metric", 1.0, optionThatCausesError, WithErrorHandler(localErrHandler))
+	assert.Equal(t, 1, globalCount)
+	assert.Equal(t, 1, localCount)
+
+	Gauge("some_metric", 1.0, optionThatCausesError)
+	assert.Equal(t, 2, globalCount)
+	assert.Equal(t, 1, localCount)
+}


### PR DESCRIPTION
Use the same options-type (both the struct, and the functional argument) for the global metric options and the per-metric options. This means that we can use the same "WithSampleRate", "WithTag" etc for the global and the per-metric options. It also allows for configuring a custom errorhandler for a single metric (e.g. where it is imperative that we are able to report the metric)

Also, if an error happens during resolving of per-metric options, then the error-handler will be used (global, or successfully set with per-metric options)

This PR is stacked on #524, and will not prevent us from completing #527
