### PR TITLE
feat: Add a logging adapter for go-logger

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/internal/log"
 	"github.com/coopnorge/go-datadog-lib/v2/metrics"
-	datadogLogger "github.com/coopnorge/go-logger/adapter/datadog"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
@@ -49,7 +49,7 @@ func Start(ctx context.Context, opts ...Option) (StopFunc, error) {
 		return noop, err
 	}
 
-	l, err := datadogLogger.NewLogger(datadogLogger.WithGlobalLogger())
+	l, err := log.NewLogger(log.WithGlobalLogger())
 	if err != nil {
 		return noop, fmt.Errorf("failed to initialize the Datadog logger: %w", err)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,64 @@
+package log
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/coopnorge/go-logger"
+)
+
+// Logger is a logging adapter between gopkg.in/DataDog/dd-trace-go.v1/ddtrace
+// an go-logger, do not create this directly, use NewLogger()
+type Logger struct {
+	instance *logger.Logger
+}
+
+// NewLogger creates a new Datadog logger that passes message to go-logger
+//
+// To inject the logger into ddtrace use
+//
+//	package main
+//
+//	import (
+//		"github.com/coopnorge/go-logger/adapter/datadog"
+//
+//		"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+//	)
+//
+//	func main() {
+//		l, err := datadog.NewLogger(datadog.WithGlobalLogger())
+//		ddtrace.UseLogger(l)
+//	}
+func NewLogger(opts ...LoggerOption) (*Logger, error) {
+	logger := &Logger{}
+	for _, opt := range opts {
+		opt.Apply(logger)
+	}
+	if logger.instance == nil {
+		return nil, errors.New("no go-logger instance provided, use WithGlobalLogger() or WithLogger() to configure the logger")
+	}
+	return logger, nil
+}
+
+// Log writes statements to the log
+func (l *Logger) Log(msg string) {
+	// Logs from gopkg.in/DataDog/dd-trace-go.v1/ddtrace will contain keywords
+	// specifying the level of the log.
+	if strings.Contains(msg, "ERROR") {
+		l.instance.Error(msg)
+		return
+	}
+	if strings.Contains(msg, "WARN") {
+		l.instance.Warn(msg)
+		return
+	}
+	if strings.Contains(msg, "INFO") {
+		l.instance.Info(msg)
+		return
+	}
+	if strings.Contains(msg, "DEBUG") {
+		l.instance.Debug(msg)
+		return
+	}
+	l.instance.WithField("datadog", "Datadog logger adapter could not resolve the logging level, falling back to warning").Warn(msg)
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,71 @@
+package log_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/coopnorge/go-datadog-lib/v2/internal/log"
+	coopLogger "github.com/coopnorge/go-logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+)
+
+func TestSetup(t *testing.T) {
+	logger, err := log.NewLogger(log.WithGlobalLogger())
+	require.NoError(t, err)
+	ddtrace.UseLogger(logger)
+}
+
+func TestGlobalLogger(t *testing.T) {
+	output := &strings.Builder{}
+	coopLogger.ConfigureGlobalLogger(coopLogger.WithLevel(coopLogger.LevelDebug), coopLogger.WithOutput(output))
+	logger, err := log.NewLogger(log.WithGlobalLogger())
+	require.NoError(t, err)
+
+	tests := []struct {
+		level string
+		msg   string
+	}{
+		{"error", "Datadog Tracer v1.63.0 ERROR This is a test"},
+		{"warning", "Datadog Tracer v1.63.0 WARN This is a test"},
+		{"info", "Datadog Tracer v1.63.0 INFO This is a test"},
+		{"debug", "Datadog Tracer v1.63.0 DEBUG This is a test"},
+		{"warning", "Datadog Tracer v1.63.0 This is a test for fallback level"},
+	}
+	for _, test := range tests {
+		t.Run(test.level, func(t *testing.T) {
+			output.Reset()
+			logger.Log(test.msg)
+			assert.Contains(t, output.String(), fmt.Sprintf("\"level\":\"%v\"", test.level))
+			assert.Contains(t, output.String(), test.msg)
+		})
+	}
+}
+
+func TestCustomLogger(t *testing.T) {
+	output := &strings.Builder{}
+	logger, err := log.NewLogger(log.WithLogger(coopLogger.New(coopLogger.WithLevel(coopLogger.LevelDebug), coopLogger.WithOutput(output))))
+	require.NoError(t, err)
+
+	tests := []struct {
+		level string
+		msg   string
+	}{
+		{"error", "Datadog Tracer v1.63.0 ERROR This is a test"},
+		{"warning", "Datadog Tracer v1.63.0 WARN This is a test"},
+		{"info", "Datadog Tracer v1.63.0 INFO This is a test"},
+		{"debug", "Datadog Tracer v1.63.0 DEBUG This is a test"},
+		{"warning", "Datadog Tracer v1.63.0 This is a test for fallback level"},
+	}
+	for _, test := range tests {
+		t.Run(test.level, func(t *testing.T) {
+			output.Reset()
+			logger.Log(test.msg)
+			assert.Contains(t, output.String(), fmt.Sprintf("\"level\":\"%v\"", test.level))
+			assert.Contains(t, output.String(), test.msg)
+		})
+	}
+}

--- a/internal/log/option.go
+++ b/internal/log/option.go
@@ -1,0 +1,32 @@
+package log
+
+import (
+	"github.com/coopnorge/go-logger"
+)
+
+// LoggerOption defines an applicator interface
+type LoggerOption interface { //nolint:all
+	Apply(l *Logger)
+}
+
+// LoggerOptionFunc defines a function which modifies a logger
+type LoggerOptionFunc func(l *Logger) //nolint:all
+
+// Apply redirects a function call to the function receiver
+func (lof LoggerOptionFunc) Apply(l *Logger) {
+	lof(l)
+}
+
+// WithGlobalLogger configures Grom to use our global logger
+func WithGlobalLogger() LoggerOption {
+	return LoggerOptionFunc(func(l *Logger) {
+		l.instance = logger.Global()
+	})
+}
+
+// WithLogger configures Grom to use a logger instance
+func WithLogger(logger *logger.Logger) LoggerOption {
+	return LoggerOptionFunc(func(l *Logger) {
+		l.instance = logger
+	})
+}

--- a/legacy_bootstrap.go
+++ b/legacy_bootstrap.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/coopnorge/go-datadog-lib/v2/config"
 	"github.com/coopnorge/go-datadog-lib/v2/internal"
+	"github.com/coopnorge/go-datadog-lib/v2/internal/log"
 	"github.com/coopnorge/go-logger"
-	datadogLogger "github.com/coopnorge/go-logger/adapter/datadog"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -48,7 +48,7 @@ func StartDatadog(cfg config.DatadogParameters, connectionType ConnectionType) e
 		return fmt.Errorf("the Datadog configuration not valid, cannot initialize Datadog services: %w", err)
 	}
 
-	l, err := datadogLogger.NewLogger(datadogLogger.WithGlobalLogger())
+	l, err := log.NewLogger(log.WithGlobalLogger())
 	if err != nil {
 		return fmt.Errorf("failed to initialize the Datadog logger: %w", err)
 	}


### PR DESCRIPTION
This change moves the Datadog logging adapter from `go-logger` to
`go-datadog-lib`. With the recent changes to `dd-trace-go` `go-logger` should not
have a dependency on `dd-trace-go` so this is better implemented in
`go-datadog-lib` that must a dependency on `go-logger`. Nothing should use this
adapter directly outside of `go-datadog-lib` therefor it is implemented as a
internal package.
