### PR TITLE
feat: Global Client func to access the statsd client

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -167,3 +167,10 @@ func getLocalOpts() *options {
 		tags:         nil, // Note: We are not copying the global tags, since they have already been passed to the StatsD-client.
 	}
 }
+
+// GlobalClient is allows to grab the client so that the legacy codebases
+// using a statsd.Client can proceed to migrate and for those edge cases
+// where the package requires hand metric sending.
+func GlobalClient() statsd.ClientInterface {
+	return statsdClient
+}


### PR DESCRIPTION
Allowing to grab the Global client is a pattern that is everywhere in telemetry. This simplifies for those edge cases where configuration is required.

Couple of scenarios that come to mind as well

1. Interoperability with 3rd-Party Middleware
2. Gradual Refactoring -> Migration ease 
3. Datadog supports complex Event types (priority, alert type, aggregation key) and Service Checks

If you hide the client, but a team desperately needs a statsd.ClientInterface (for a library or legacy code), they will simply instantiate their own. 