### PR TITLE
docs(catalog): add description, tags and promote lifecycle

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,9 +3,17 @@ kind: Component
 metadata:
   name: go-datadog-lib
   title: Go Datadog Library
+  description: >-
+    Datadog APM and metrics integration for Go services. One-call
+    initialisation with distributed tracing middleware for gRPC, HTTP, SQL
+    and GORM. Provides a go-logger hook for trace-correlated log entries.
   tags:
-    - "go"
-    - "pkg"
+    - go
+    - datadog
+    - tracing
+    - metrics
+    - observability
+    - apm
   annotations:
     github.com/project-slug: coopnorge/go-datadog-lib
     backstage.io/techdocs-ref: dir:.
@@ -18,7 +26,7 @@ metadata:
       icon: web
 spec:
   type: library
-  lifecycle: experimental
+  lifecycle: production
   owner: engineering
   dependsOn:
     - component:devtools-golang-v1beta1


### PR DESCRIPTION
The catalog entry lacked a description and meaningful tags, making
it invisible to AI-assisted tooling and hard to discover in
Backstage. Lifecycle promoted to production to reflect actual
adoption across the organisation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
