### PR TITLE
chore(catalog): Remove library and devtool deps from spec.dependsOn

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,10 +28,3 @@ spec:
   type: library
   lifecycle: production
   owner: engineering
-  dependsOn:
-    - component:devtools-golang-v1beta1
-    - component:github-workflow-supply-chain-security-validation
-    - component:github-workflow-techdocs
-    - component:go-logger
-    - component:techdocs
-    - component:vale-coop


### PR DESCRIPTION
Libraries and devtools should not appear in spec.dependsOn. These
dependencies are already tracked by GitHub (via repository
dependencies and code ownership), so listing them in Backstage adds
no value. More importantly, Backstage propagates dependsOn into
Datadog Service Catalog, where these spurious edges create noise in
service dependency graphs and alert routing.

The dependsOn relation is intended to express runtime or deployment
dependencies between entities -- not tooling or shared-library
relationships.

Remove all Component references of type library or devtool from
spec.dependsOn in this repo's catalog-info.yaml. Where removing
those entries empties the list, the dependsOn key is removed
entirely.